### PR TITLE
Add blank tile letter picker and QR code lobby sharing

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -15,6 +15,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "peerjs": "^1.5.5",
+    "qrcode.react": "^4.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/packages/client/src/components/board/GameBoard.tsx
+++ b/packages/client/src/components/board/GameBoard.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import type { PlacedTile } from '@blitztiles/shared';
 import { BoardCell } from './BoardCell';
+import { BlankTilePicker } from '../tiles/BlankTilePicker';
 import { useGameStore } from '../../hooks/useGameStore';
 import './GameBoard.css';
 
@@ -7,9 +9,16 @@ export function GameBoard() {
   const board = useGameStore((s) => s.board);
   const placedTiles = useGameStore((s) => s.placedTiles);
   const selectedTileId = useGameStore((s) => s.selectedTileId);
+  const currentHand = useGameStore((s) => s.currentHand);
   const placeTile = useGameStore((s) => s.placeTile);
   const removePlacedTile = useGameStore((s) => s.removePlacedTile);
   const phase = useGameStore((s) => s.phase);
+
+  const [pendingBlank, setPendingBlank] = useState<{
+    tileId: string;
+    row: number;
+    col: number;
+  } | null>(null);
 
   if (!board || board.length === 0) return null;
 
@@ -22,14 +31,17 @@ export function GameBoard() {
 
     const pending = getPendingTile(row, col);
     if (pending) {
-      // Clicking a pending tile removes it from the board
       removePlacedTile(pending.id);
       return;
     }
 
-    // If a tile is selected and the cell is empty, place it
     if (selectedTileId && !board[row][col].tile) {
-      placeTile(selectedTileId, row, col);
+      const tile = currentHand.find((t) => t.id === selectedTileId);
+      if (tile?.isBlank) {
+        setPendingBlank({ tileId: selectedTileId, row, col });
+      } else {
+        placeTile(selectedTileId, row, col);
+      }
     }
   };
 
@@ -48,6 +60,15 @@ export function GameBoard() {
           )),
         )}
       </div>
+      {pendingBlank && (
+        <BlankTilePicker
+          onSelect={(letter) => {
+            placeTile(pendingBlank.tileId, pendingBlank.row, pendingBlank.col, letter);
+            setPendingBlank(null);
+          }}
+          onCancel={() => setPendingBlank(null)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/tiles/BlankTilePicker.css
+++ b/packages/client/src/components/tiles/BlankTilePicker.css
@@ -1,0 +1,77 @@
+.blank-picker-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+  backdrop-filter: blur(4px);
+}
+
+.blank-picker-modal {
+  background: var(--bg-secondary);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  padding: 24px;
+  text-align: center;
+  max-width: 320px;
+  width: 90%;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+
+.blank-picker-title {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+
+.blank-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.blank-picker-letter {
+  aspect-ratio: 1;
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  font-weight: 700;
+  background: var(--tile-bg, #e8c170);
+  color: var(--text, #1a1a2e);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    transform 0.1s,
+    box-shadow 0.1s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.blank-picker-letter:hover {
+  transform: scale(1.08);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.blank-picker-letter:active {
+  transform: scale(0.95);
+}
+
+.blank-picker-cancel {
+  padding: 8px 24px;
+  font-size: 0.9rem;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.blank-picker-cancel:hover {
+  background: rgba(255, 255, 255, 0.05);
+}

--- a/packages/client/src/components/tiles/BlankTilePicker.tsx
+++ b/packages/client/src/components/tiles/BlankTilePicker.tsx
@@ -1,0 +1,28 @@
+import './BlankTilePicker.css';
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+
+interface BlankTilePickerProps {
+  onSelect: (letter: string) => void;
+  onCancel: () => void;
+}
+
+export function BlankTilePicker({ onSelect, onCancel }: BlankTilePickerProps) {
+  return (
+    <div className="blank-picker-overlay" onClick={onCancel}>
+      <div className="blank-picker-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="blank-picker-title">Choose a letter</div>
+        <div className="blank-picker-grid">
+          {LETTERS.map((letter) => (
+            <button key={letter} className="blank-picker-letter" onClick={() => onSelect(letter)}>
+              {letter}
+            </button>
+          ))}
+        </div>
+        <button className="blank-picker-cancel" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/pages/GamePage.css
+++ b/packages/client/src/pages/GamePage.css
@@ -71,6 +71,38 @@
   margin-bottom: 24px;
 }
 
+.lobby-qr {
+  margin: 16px 0;
+}
+
+.lobby-share-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.btn-copy-link {
+  padding: 8px 20px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: var(--accent, #e94560);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.btn-copy-link:hover {
+  opacity: 0.85;
+}
+
+.btn-copy-link:active {
+  opacity: 0.7;
+}
+
 .error-box {
   text-align: center;
   color: var(--danger);

--- a/packages/client/src/pages/GamePage.tsx
+++ b/packages/client/src/pages/GamePage.tsx
@@ -9,13 +9,15 @@ import {
   useSensors,
   rectIntersection,
 } from '@dnd-kit/core';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { GameBoard } from '../components/board/GameBoard';
 import { TileRack } from '../components/tiles/TileRack';
 import { GameHeader } from '../components/game/GameHeader';
 import { GameControls } from '../components/game/GameControls';
 import { GameOverModal } from '../components/game/GameOverModal';
+import { BlankTilePicker } from '../components/tiles/BlankTilePicker';
+import { QRCodeSVG } from 'qrcode.react';
 import { useGameStore } from '../hooks/useGameStore';
 import { useGameConnection } from '../hooks/useGameConnection';
 import './GamePage.css';
@@ -40,10 +42,16 @@ function LocalGame() {
   const phase = useGameStore((s) => s.phase);
   const initLocalGame = useGameStore((s) => s.initLocalGame);
   const dictionaryLoaded = useGameStore((s) => s.dictionaryLoaded);
+  const currentHand = useGameStore((s) => s.currentHand);
   const placeTile = useGameStore((s) => s.placeTile);
   const reorderHand = useGameStore((s) => s.reorderHand);
-  const currentHand = useGameStore((s) => s.currentHand);
   const [activeTileId, setActiveTileId] = useState<string | null>(null);
+
+  const [pendingBlank, setPendingBlank] = useState<{
+    tileId: string;
+    row: number;
+    col: number;
+  } | null>(null);
 
   // Configure sensors for DndContext
   const sensors = useSensors(
@@ -64,26 +72,35 @@ function LocalGame() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
 
-    if (!over) return;
+      if (!over) return;
 
-    if (active.id === over.id) return;
+      if (active.id === over.id) return;
 
-    const activeType = active.data.current?.type;
-    const overType = over.data.current?.type;
+      const activeType = active.data.current?.type;
+      const overType = over.data.current?.type;
 
-    if (activeType === 'rack-tile' && overType === 'rack-tile') {
-      reorderHand(active.id as string, over.id as string);
-    } else if (
-      (activeType === 'rack-tile' || activeType === 'board-tile') &&
-      over.id.toString().startsWith('cell-')
-    ) {
-      const [_, row, col] = over.id.toString().split('-');
-      placeTile(active.id as string, parseInt(row), parseInt(col));
-    }
-  };
+      if (activeType === 'rack-tile' && overType === 'rack-tile') {
+        reorderHand(active.id as string, over.id as string);
+      } else if (
+        (activeType === 'rack-tile' || activeType === 'board-tile') &&
+        over.id.toString().startsWith('cell-')
+      ) {
+        const [, row, col] = over.id.toString().split('-');
+        const tileId = active.id as string;
+        const tile = currentHand.find((t) => t.id === tileId);
+        if (tile?.isBlank) {
+          setPendingBlank({ tileId, row: parseInt(row), col: parseInt(col) });
+        } else {
+          placeTile(tileId, parseInt(row), parseInt(col));
+        }
+      }
+    },
+    [currentHand, placeTile, reorderHand],
+  );
 
   const activeTile = currentHand.find((t) => t.id === activeTileId) || null;
 
@@ -118,15 +135,20 @@ function LocalGame() {
       <DragOverlay dropAnimation={null}>
         {activeTile ? (
           <div className="drag-overlay-tile">
-            <span className="rack-tile-letter">
-              {activeTile.isBlank ? '' : activeTile.letter}
-            </span>
-            {activeTile.value > 0 && (
-              <span className="rack-tile-value">{activeTile.value}</span>
-            )}
+            <span className="rack-tile-letter">{activeTile.isBlank ? '' : activeTile.letter}</span>
+            {activeTile.value > 0 && <span className="rack-tile-value">{activeTile.value}</span>}
           </div>
         ) : null}
       </DragOverlay>
+      {pendingBlank && (
+        <BlankTilePicker
+          onSelect={(letter) => {
+            placeTile(pendingBlank.tileId, pendingBlank.row, pendingBlank.col, letter);
+            setPendingBlank(null);
+          }}
+          onCancel={() => setPendingBlank(null)}
+        />
+      )}
     </DndContext>
   );
 }
@@ -145,12 +167,17 @@ function OnlineGame({ role, joinCode }: { role: 'host' | 'guest'; joinCode: stri
   const initGuestGame = useGameStore((s) => s.initGuestGame);
   const setConnection = useGameStore((s) => s.setConnection);
   const handleNetworkMessage = useGameStore((s) => s.handleNetworkMessage);
+  const currentHand = useGameStore((s) => s.currentHand);
   const placeTile = useGameStore((s) => s.placeTile);
   const reorderHand = useGameStore((s) => s.reorderHand);
-  const currentHand = useGameStore((s) => s.currentHand);
 
   const [initialized, setInitialized] = useState(false);
   const [activeTileId, setActiveTileId] = useState<string | null>(null);
+  const [pendingBlank, setPendingBlank] = useState<{
+    tileId: string;
+    row: number;
+    col: number;
+  } | null>(null);
 
   // Configure sensors for DndContext
   const sensors = useSensors(
@@ -194,26 +221,35 @@ function OnlineGame({ role, joinCode }: { role: 'host' | 'guest'; joinCode: stri
   const gameReady =
     connection.status === 'connected' && initialized && dictionaryLoaded && phase === 'playing';
 
-  const handleDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event;
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
 
-    if (!over) return;
+      if (!over) return;
 
-    if (active.id === over.id) return;
+      if (active.id === over.id) return;
 
-    const activeType = active.data.current?.type;
-    const overType = over.data.current?.type;
+      const activeType = active.data.current?.type;
+      const overType = over.data.current?.type;
 
-    if (activeType === 'rack-tile' && overType === 'rack-tile') {
-      reorderHand(active.id as string, over.id as string);
-    } else if (
-      (activeType === 'rack-tile' || activeType === 'board-tile') &&
-      over.id.toString().startsWith('cell-')
-    ) {
-      const [_, row, col] = over.id.toString().split('-');
-      placeTile(active.id as string, parseInt(row), parseInt(col));
-    }
-  };
+      if (activeType === 'rack-tile' && overType === 'rack-tile') {
+        reorderHand(active.id as string, over.id as string);
+      } else if (
+        (activeType === 'rack-tile' || activeType === 'board-tile') &&
+        over.id.toString().startsWith('cell-')
+      ) {
+        const [, row, col] = over.id.toString().split('-');
+        const tileId = active.id as string;
+        const tile = currentHand.find((t) => t.id === tileId);
+        if (tile?.isBlank) {
+          setPendingBlank({ tileId, row: parseInt(row), col: parseInt(col) });
+        } else {
+          placeTile(tileId, parseInt(row), parseInt(col));
+        }
+      }
+    },
+    [currentHand, placeTile, reorderHand],
+  );
 
   const activeTile = currentHand.find((t) => t.id === activeTileId) || null;
 
@@ -223,14 +259,7 @@ function OnlineGame({ role, joinCode }: { role: 'host' | 'guest'; joinCode: stri
         <div className="online-lobby">
           {connection.status === 'connecting' && <div className="loading-text">Connecting...</div>}
 
-          {connection.status === 'waiting' && (
-            <>
-              <div className="lobby-label">Room Code</div>
-              <div className="room-code">{connection.roomCode}</div>
-              <div className="lobby-hint">Share this code with your opponent</div>
-              <div className="loading-text">Waiting for opponent...</div>
-            </>
-          )}
+          {connection.status === 'waiting' && <LobbyShare roomCode={connection.roomCode ?? ''} />}
 
           {connection.status === 'connected' && !gameReady && (
             <div className="loading-text">Starting game...</div>
@@ -282,15 +311,72 @@ function OnlineGame({ role, joinCode }: { role: 'host' | 'guest'; joinCode: stri
       <DragOverlay dropAnimation={null}>
         {activeTile ? (
           <div className="drag-overlay-tile">
-            <span className="rack-tile-letter">
-              {activeTile.isBlank ? '' : activeTile.letter}
-            </span>
-            {activeTile.value > 0 && (
-              <span className="rack-tile-value">{activeTile.value}</span>
-            )}
+            <span className="rack-tile-letter">{activeTile.isBlank ? '' : activeTile.letter}</span>
+            {activeTile.value > 0 && <span className="rack-tile-value">{activeTile.value}</span>}
           </div>
         ) : null}
       </DragOverlay>
+      {pendingBlank && (
+        <BlankTilePicker
+          onSelect={(letter) => {
+            placeTile(pendingBlank.tileId, pendingBlank.row, pendingBlank.col, letter);
+            setPendingBlank(null);
+          }}
+          onCancel={() => setPendingBlank(null)}
+        />
+      )}
     </DndContext>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Lobby share widget (QR code + copy link)
+// ---------------------------------------------------------------------------
+
+function LobbyShare({ roomCode }: { roomCode: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const shareUrl = `${window.location.origin}/game?mode=guest&code=${roomCode}`;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: select the text so the user can copy manually
+    }
+  };
+
+  const handleShare = async () => {
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: 'Join my BlitzTiles game', url: shareUrl });
+      } catch {
+        // User cancelled or share failed
+      }
+    }
+  };
+
+  return (
+    <>
+      <div className="lobby-label">Room Code</div>
+      <div className="room-code">{roomCode}</div>
+      <div className="lobby-qr">
+        <QRCodeSVG value={shareUrl} size={160} bgColor="transparent" fgColor="#ffffff" />
+      </div>
+      <div className="lobby-share-buttons">
+        <button className="btn-copy-link" onClick={handleCopy}>
+          {copied ? 'Copied!' : 'Copy Link'}
+        </button>
+        {typeof navigator.share === 'function' && (
+          <button className="btn-copy-link" onClick={handleShare}>
+            Share
+          </button>
+        )}
+      </div>
+      <div className="lobby-hint">Share this link or scan the QR code</div>
+      <div className="loading-text">Waiting for opponent...</div>
+    </>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       peerjs:
         specifier: ^1.5.5
         version: 1.5.5
+      qrcode.react:
+        specifier: ^4.2.0
+        version: 4.2.0(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1378,6 +1381,11 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  qrcode.react@4.2.0:
+    resolution: {integrity: sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -2883,6 +2891,10 @@ snapshots:
   prettier@3.8.1: {}
 
   punycode@2.3.1: {}
+
+  qrcode.react@4.2.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary
- **Blank tile picker**: When placing a blank tile (click or drag), an A-Z grid modal appears so players can choose a letter instead of defaulting to 'A'
- **QR code + share link**: Host lobby now shows a QR code and copy-link button (+ Web Share API on mobile) so opponents can join easily

Closes #6, closes #7

## Changes
- New `BlankTilePicker` component + CSS (overlay modal with 26-letter grid, 44px touch targets)
- `GameBoard.tsx`: intercepts blank tile click-placement to show picker
- `GamePage.tsx`: intercepts blank tile drag-placement in both `LocalGame` and `OnlineGame`
- `GamePage.tsx`: new `LobbyShare` component with `QRCodeSVG` and clipboard/share buttons
- `GamePage.css`: styles for QR wrapper, copy button with "Copied!" feedback
- Added `qrcode.react` dependency

## Test plan
- [ ] Place blank tile via click → picker appears → select letter → tile shows chosen letter on board
- [ ] Place blank tile via drag → same picker behavior
- [ ] Cancel picker → tile not placed, returns to hand
- [ ] Create online game → lobby shows QR code + copy link button
- [ ] Copy link → clipboard contains correct join URL
- [ ] `pnpm lint && pnpm typecheck && pnpm test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)