### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/packages/client/src/components/settings/SettingsPanel.css
+++ b/packages/client/src/components/settings/SettingsPanel.css
@@ -64,3 +64,33 @@
 .toggle-switch.on .toggle-knob {
   transform: translateX(18px);
 }
+
+/* Theme toggle */
+.theme-toggle {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.theme-option {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-weight: 500;
+}
+
+.theme-option.active {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.theme-option:hover:not(.active) {
+  background: rgba(128, 128, 128, 0.1);
+  border-color: rgba(128, 128, 128, 0.3);
+}

--- a/packages/client/src/components/settings/SettingsPanel.tsx
+++ b/packages/client/src/components/settings/SettingsPanel.tsx
@@ -1,4 +1,5 @@
 import { useSettingsStore, type Settings } from '../../hooks/useSettingsStore';
+import { useTheme } from '../../hooks/useTheme';
 import './SettingsPanel.css';
 
 const toggles: { key: keyof Settings; label: string; description: string }[] = [
@@ -32,9 +33,33 @@ const toggles: { key: keyof Settings; label: string; description: string }[] = [
 
 export function SettingsPanel() {
   const store = useSettingsStore();
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <div className="settings-panel">
+      {/* Theme toggle */}
+      <div className="settings-row theme-row">
+        <div className="settings-label">
+          <span className="settings-name">Theme</span>
+          <span className="settings-desc">Switch between dark and light mode</span>
+        </div>
+        <div className="theme-toggle">
+          <button
+            className={`theme-option ${theme === 'dark' ? 'active' : ''}`}
+            onClick={() => theme !== 'dark' && toggleTheme()}
+          >
+            🌙 Dark
+          </button>
+          <button
+            className={`theme-option ${theme === 'light' ? 'active' : ''}`}
+            onClick={() => theme !== 'light' && toggleTheme()}
+          >
+            ☀️ Light
+          </button>
+        </div>
+      </div>
+
+      {/* Other settings toggles */}
       {toggles.map(({ key, label, description }) => (
         <label key={key} className="settings-row">
           <div className="settings-label">

--- a/packages/client/src/hooks/useSettingsStore.ts
+++ b/packages/client/src/hooks/useSettingsStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 export interface Settings {
+  theme: 'dark' | 'light';
   leftHanded: boolean;
   autoZoom: boolean;
   scorePreview: boolean;
@@ -12,11 +13,13 @@ export interface Settings {
 
 interface SettingsStore extends Settings {
   set: <K extends keyof Settings>(key: K, value: Settings[K]) => void;
+  toggleTheme: () => void;
 }
 
 export const useSettingsStore = create<SettingsStore>()(
   persist(
     (set) => ({
+      theme: 'dark',
       leftHanded: false,
       autoZoom: true,
       scorePreview: true,
@@ -24,6 +27,7 @@ export const useSettingsStore = create<SettingsStore>()(
       scorePopup: true,
       timerUrgency: true,
       set: (key, value) => set({ [key]: value }),
+      toggleTheme: () => set((state) => ({ theme: state.theme === 'dark' ? 'light' : 'dark' })),
     }),
     { name: 'blitztiles-settings' },
   ),

--- a/packages/client/src/hooks/useTheme.ts
+++ b/packages/client/src/hooks/useTheme.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useSettingsStore } from './useSettingsStore';
+
+export function useTheme() {
+  const theme = useSettingsStore((s) => s.theme);
+  const toggleTheme = useSettingsStore((s) => s.toggleTheme);
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  return { theme, toggleTheme };
+}

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -4,7 +4,12 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { HomePage } from './pages/HomePage';
 import { GamePage } from './pages/GamePage';
 import { SettingsPage } from './pages/SettingsPage';
+import { useSettingsStore } from './hooks/useSettingsStore';
 import './styles/global.css';
+
+// Apply theme synchronously before React renders to prevent flash
+const initialTheme = useSettingsStore.getState().theme;
+document.documentElement.setAttribute('data-theme', initialTheme);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/packages/client/src/pages/HomePage.css
+++ b/packages/client/src/pages/HomePage.css
@@ -4,6 +4,31 @@
   align-items: center;
   justify-content: center;
   padding: 24px;
+  position: relative;
+}
+
+.theme-toggle-icon {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0.5rem;
+  opacity: 0.7;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
+}
+
+.theme-toggle-icon:hover {
+  opacity: 1;
+  transform: scale(1.1);
+}
+
+.theme-toggle-icon:active {
+  transform: scale(1) !important;
 }
 
 .home-content {

--- a/packages/client/src/pages/HomePage.tsx
+++ b/packages/client/src/pages/HomePage.tsx
@@ -2,10 +2,12 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { QRCodeSVG } from 'qrcode.react';
 import { hasActiveSession, loadSession, clearSession } from '../hooks/sessionPersistence';
+import { useTheme } from '../hooks/useTheme';
 import './HomePage.css';
 
 export function HomePage() {
   const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
   const [joinCode, setJoinCode] = useState('');
   const [showJoin, setShowJoin] = useState(false);
   const [showResume, setShowResume] = useState(hasActiveSession);
@@ -33,6 +35,9 @@ export function HomePage() {
 
   return (
     <div className="home-page">
+      <button className="theme-toggle-icon" onClick={toggleTheme} aria-label="Toggle theme">
+        {theme === 'dark' ? '☀️' : '🌙'}
+      </button>
       <div className="home-content">
         <h1 className="home-title">BlitzTiles</h1>
         <p className="home-subtitle">Word game with a clock</p>

--- a/packages/client/src/styles/global.css
+++ b/packages/client/src/styles/global.css
@@ -38,6 +38,17 @@
   box-sizing: border-box;
 }
 
+/* Add smooth transitions for theme switching */
+html,
+body,
+button,
+input {
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease,
+    border-color 0.3s ease;
+}
+
 html,
 body {
   height: 100%;
@@ -100,4 +111,44 @@ button:disabled {
 
 .btn-secondary:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.1);
+}
+
+/* Light theme palette */
+[data-theme='light'] {
+  /* Backgrounds */
+  --bg: #f5f5f7;
+  --bg-secondary: #ffffff;
+  --bg-card: #fafafa;
+
+  /* Text */
+  --text: #1d1d1f;
+  --text-muted: #6e6e73;
+
+  /* Accent */
+  --accent: #9966cc;
+  --accent-hover: #7744aa;
+
+  /* Tiles (dark on light - classic Scrabble) */
+  --tile-bg: #2c2c2c;
+  --tile-text: #f5f5f5;
+  --tile-border: #1a1a1a;
+  --tile-selected: #9966cc;
+
+  /* Board (warm wood tones) */
+  --board-bg: #dcd4c8;
+  --board-border: #b8afa0;
+  --cell-bg: #e8e3d8;
+  --cell-border: #d0c9bc;
+
+  /* Bonus squares (brighter for visibility) */
+  --dl: #87ceeb; /* Sky blue */
+  --tl: #6a5acd; /* Slate blue */
+  --dw: #f0e68c; /* Khaki yellow */
+  --tw: #dc143c; /* Crimson red */
+  --center: #ffa500; /* Orange */
+
+  /* Status colors (darker for contrast) */
+  --success: #00a86b;
+  --warning: #ff8c00;
+  --danger: #c41e3a;
 }


### PR DESCRIPTION
Implement theme switching with localStorage persistence, allowing users to choose between dark and light modes. Light theme features warm wood-tone board colors and dark tiles (classic Scrabble aesthetic) for improved visibility and variety.

- Extend useSettingsStore with theme field and toggleTheme method
- Add useTheme hook to sync theme with HTML data-theme attribute
- Initialize theme synchronously in main.tsx to prevent FOUC
- Define light mode color palette in global.css with smooth transitions
- Add theme toggle UI to Settings panel (dual-button control)
- Add quick-access theme toggle icon to HomePage (top-right)
- All theme changes persist automatically via Zustand middleware