### PR TITLE
Add keyboard controls for tile placement

### DIFF
--- a/packages/client/src/components/board/BoardCell.css
+++ b/packages/client/src/components/board/BoardCell.css
@@ -31,6 +31,22 @@
   box-shadow: inset 0 0 0 2px var(--tile-selected);
 }
 
+.board-cell.cursor {
+  background: rgba(52, 211, 153, 0.2);
+  box-shadow: inset 0 0 0 2px rgba(52, 211, 153, 0.8);
+  animation: cursor-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes cursor-pulse {
+  0%,
+  100% {
+    box-shadow: inset 0 0 0 2px rgba(52, 211, 153, 0.8);
+  }
+  50% {
+    box-shadow: inset 0 0 0 2px rgba(52, 211, 153, 1);
+  }
+}
+
 /* Bonus square colors */
 .board-cell.bonus-dl {
   background: var(--dl);

--- a/packages/client/src/components/board/BoardCell.tsx
+++ b/packages/client/src/components/board/BoardCell.tsx
@@ -14,6 +14,7 @@ interface BoardCellProps {
   pendingTile?: PlacedTile;
   isSelected: boolean;
   isLastMove: boolean;
+  isCursor?: boolean;
   pendingEdges?: EdgeFlags;
   lastMoveEdges?: EdgeFlags;
   scorePreview?: number | null;
@@ -32,6 +33,7 @@ export function BoardCell({
   pendingTile,
   isSelected,
   isLastMove,
+  isCursor = false,
   pendingEdges,
   lastMoveEdges,
   scorePreview,
@@ -67,6 +69,7 @@ export function BoardCell({
     isPending ? 'pending' : '',
     isOver ? 'drag-over' : '',
     isLastMove ? 'last-move' : '',
+    isCursor ? 'cursor' : '',
   ]
     .filter(Boolean)
     .join(' ');

--- a/packages/client/src/components/board/GameBoard.tsx
+++ b/packages/client/src/components/board/GameBoard.tsx
@@ -18,6 +18,7 @@ export function GameBoard({ isDragging = false }: { isDragging?: boolean }) {
   const setBlankLetter = useGameStore((s) => s.setBlankLetter);
   const phase = useGameStore((s) => s.phase);
   const lastMoveTiles = useGameStore((s) => s.lastMoveTiles);
+  const cursorPosition = useGameStore((s) => s.cursorPosition);
   const autoZoomEnabled = useSettingsStore((s) => s.autoZoom);
   const scorePreviewEnabled = useSettingsStore((s) => s.scorePreview);
   const lastMoveHighlightEnabled = useSettingsStore((s) => s.lastMoveHighlight);
@@ -172,6 +173,7 @@ export function GameBoard({ isDragging = false }: { isDragging?: boolean }) {
           row.map((cell, colIdx) => {
             const isInWord = wordSet.has(`${rowIdx},${colIdx}`);
             const isLastMove = lastMoveHighlightEnabled && lastMoveSet.has(`${rowIdx},${colIdx}`);
+            const isCursor = cursorPosition?.row === rowIdx && cursorPosition?.col === colIdx;
             return (
               <BoardCell
                 key={`${rowIdx}-${colIdx}`}
@@ -179,6 +181,7 @@ export function GameBoard({ isDragging = false }: { isDragging?: boolean }) {
                 pendingTile={getPendingTile(rowIdx, colIdx)}
                 isSelected={false}
                 isLastMove={isLastMove}
+                isCursor={isCursor}
                 pendingEdges={
                   isInWord
                     ? {

--- a/packages/client/src/hooks/useGameStore.ts
+++ b/packages/client/src/hooks/useGameStore.ts
@@ -67,6 +67,8 @@ export interface GameStore {
   lastMoveTiles: { row: number; col: number }[];
   exchangeMode: boolean;
   exchangeSelection: Set<string>;
+  cursorPosition: { row: number; col: number } | null;
+  cursorDirection: 'horizontal' | 'vertical';
 
   // Network state
   mode: GameMode;
@@ -100,6 +102,10 @@ export interface GameStore {
   clearError: () => void;
   setExchangeMode: (on: boolean) => void;
   toggleExchangeTile: (tileId: string) => void;
+  setCursor: (row: number, col: number) => void;
+  clearCursor: () => void;
+  moveCursor: (direction: 'up' | 'down' | 'left' | 'right') => void;
+  toggleCursorDirection: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +261,8 @@ const INITIAL_STATE = {
   lastMoveTiles: [] as { row: number; col: number }[],
   exchangeMode: false,
   exchangeSelection: new Set<string>(),
+  cursorPosition: null as { row: number; col: number } | null,
+  cursorDirection: 'horizontal' as 'horizontal' | 'vertical',
 
   mode: 'local' as GameMode,
   playerIndex: 0,
@@ -841,5 +849,45 @@ export const useGameStore = create<GameStore>((set, get) => ({
       next.add(tileId);
     }
     set({ exchangeSelection: next });
+  },
+
+  setCursor: (row: number, col: number) => {
+    if (row < 0 || row > 14 || col < 0 || col > 14) return;
+    set({ cursorPosition: { row, col } });
+  },
+
+  clearCursor: () => {
+    set({ cursorPosition: null });
+  },
+
+  moveCursor: (direction: 'up' | 'down' | 'left' | 'right') => {
+    const { cursorPosition } = get();
+    if (!cursorPosition) {
+      // Start at center if no cursor
+      set({ cursorPosition: { row: 7, col: 7 } });
+      return;
+    }
+
+    let { row, col } = cursorPosition;
+    switch (direction) {
+      case 'up':
+        row = Math.max(0, row - 1);
+        break;
+      case 'down':
+        row = Math.min(14, row + 1);
+        break;
+      case 'left':
+        col = Math.max(0, col - 1);
+        break;
+      case 'right':
+        col = Math.min(14, col + 1);
+        break;
+    }
+    set({ cursorPosition: { row, col } });
+  },
+
+  toggleCursorDirection: () => {
+    const { cursorDirection } = get();
+    set({ cursorDirection: cursorDirection === 'horizontal' ? 'vertical' : 'horizontal' });
   },
 }));

--- a/packages/client/src/hooks/useKeyboardControls.ts
+++ b/packages/client/src/hooks/useKeyboardControls.ts
@@ -1,0 +1,189 @@
+import { useEffect, useCallback } from 'react';
+import { useGameStore } from './useGameStore';
+
+/**
+ * Hook that enables keyboard controls for tile placement.
+ *
+ * Controls:
+ * - Letter keys (A-Z): Place tile from rack at cursor position
+ * - Arrow keys: Move cursor in that direction
+ * - Delete/Backspace: Remove tile at cursor position and move cursor backward
+ * - Tab: Toggle horizontal/vertical direction
+ * - Escape: Clear cursor
+ * - Enter: Submit move
+ */
+export function useKeyboardControls(enabled: boolean = true) {
+  const phase = useGameStore((s) => s.phase);
+  const cursorPosition = useGameStore((s) => s.cursorPosition);
+  const cursorDirection = useGameStore((s) => s.cursorDirection);
+  const currentHand = useGameStore((s) => s.currentHand);
+  const placedTiles = useGameStore((s) => s.placedTiles);
+  const board = useGameStore((s) => s.board);
+  const exchangeMode = useGameStore((s) => s.exchangeMode);
+
+  const placeTile = useGameStore((s) => s.placeTile);
+  const removePlacedTile = useGameStore((s) => s.removePlacedTile);
+  const setCursor = useGameStore((s) => s.setCursor);
+  const clearCursor = useGameStore((s) => s.clearCursor);
+  const moveCursor = useGameStore((s) => s.moveCursor);
+  const toggleCursorDirection = useGameStore((s) => s.toggleCursorDirection);
+  const submitMove = useGameStore((s) => s.submitMove);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      // Ignore if not enabled or not playing
+      if (!enabled || phase !== 'playing' || exchangeMode) return;
+
+      // Ignore if typing in an input field
+      const target = event.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+
+      // Ignore if modal is open (BlankTilePicker uses buttons, not inputs)
+      if (document.querySelector('.blank-tile-picker')) return;
+
+      const key = event.key;
+
+      // Arrow keys: move cursor
+      if (key === 'ArrowUp') {
+        event.preventDefault();
+        moveCursor('up');
+        return;
+      }
+      if (key === 'ArrowDown') {
+        event.preventDefault();
+        moveCursor('down');
+        return;
+      }
+      if (key === 'ArrowLeft') {
+        event.preventDefault();
+        moveCursor('left');
+        return;
+      }
+      if (key === 'ArrowRight') {
+        event.preventDefault();
+        moveCursor('right');
+        return;
+      }
+
+      // Escape: clear cursor
+      if (key === 'Escape') {
+        event.preventDefault();
+        clearCursor();
+        return;
+      }
+
+      // Tab: toggle direction
+      if (key === 'Tab') {
+        event.preventDefault();
+        toggleCursorDirection();
+        return;
+      }
+
+      // Enter: submit move
+      if (key === 'Enter') {
+        event.preventDefault();
+        if (placedTiles.length > 0) {
+          submitMove();
+        }
+        return;
+      }
+
+      // Delete/Backspace: remove tile at cursor, then move cursor back
+      if (key === 'Backspace' || key === 'Delete') {
+        event.preventDefault();
+        if (!cursorPosition) return;
+
+        const { row, col } = cursorPosition;
+        const pending = placedTiles.find((t) => t.row === row && t.col === col);
+        if (pending) {
+          removePlacedTile(pending.id);
+        }
+
+        // Move cursor back in the current direction (like crossword navigation)
+        if (cursorDirection === 'horizontal') {
+          moveCursor('left');
+        } else {
+          moveCursor('up');
+        }
+        return;
+      }
+
+      // Letter keys (A-Z): place tile at cursor
+      const letter = key.toUpperCase();
+      if (letter.length === 1 && letter >= 'A' && letter <= 'Z') {
+        event.preventDefault();
+
+        // Initialize cursor at center if not set
+        if (!cursorPosition) {
+          setCursor(7, 7);
+          return;
+        }
+
+        const { row, col } = cursorPosition;
+
+        // Check if cell is already occupied
+        if (board[row]?.[col]?.tile) return;
+        const pending = placedTiles.find((t) => t.row === row && t.col === col);
+        if (pending) return;
+
+        // Find matching tile in hand (prefer exact match over blank)
+        let tileToPlace = currentHand.find(
+          (t) => t.letter === letter && !placedTiles.some((p) => p.id === t.id),
+        );
+
+        // If no exact match, try blank tile
+        if (!tileToPlace) {
+          tileToPlace = currentHand.find(
+            (t) => t.isBlank && !placedTiles.some((p) => p.id === t.id),
+          );
+        }
+
+        if (!tileToPlace) return;
+
+        // Place the tile (if blank, designatedLetter will be set)
+        if (tileToPlace.isBlank) {
+          placeTile(tileToPlace.id, row, col, letter);
+        } else {
+          placeTile(tileToPlace.id, row, col);
+        }
+
+        // Auto-advance cursor in current direction
+        if (cursorDirection === 'horizontal') {
+          if (col < 14) {
+            setCursor(row, col + 1);
+          }
+        } else {
+          if (row < 14) {
+            setCursor(row + 1, col);
+          }
+        }
+      }
+    },
+    [
+      enabled,
+      phase,
+      exchangeMode,
+      cursorPosition,
+      cursorDirection,
+      currentHand,
+      placedTiles,
+      board,
+      placeTile,
+      removePlacedTile,
+      setCursor,
+      clearCursor,
+      moveCursor,
+      toggleCursorDirection,
+      submitMove,
+    ],
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [enabled, handleKeyDown]);
+}

--- a/packages/client/src/pages/GamePage.tsx
+++ b/packages/client/src/pages/GamePage.tsx
@@ -23,6 +23,7 @@ import { QRCodeSVG } from 'qrcode.react';
 import { useGameStore, filterStateForPlayer } from '../hooks/useGameStore';
 import { useGameConnection } from '../hooks/useGameConnection';
 import { useWakeLock } from '../hooks/useWakeLock';
+import { useKeyboardControls } from '../hooks/useKeyboardControls';
 import { loadSession, clearSession } from '../hooks/sessionPersistence';
 import type { PersistedSession } from '../hooks/sessionPersistence';
 import './GamePage.css';
@@ -55,6 +56,7 @@ function LocalGame() {
   const [activeTileId, setActiveTileId] = useState<string | null>(null);
 
   useWakeLock(phase === 'playing');
+  useKeyboardControls(true);
 
   const [pendingBlank, setPendingBlank] = useState<{
     tileId: string;
@@ -216,6 +218,7 @@ function OnlineGame({ role, joinCode }: { role: 'host' | 'guest'; joinCode: stri
   const removePlacedTile = useGameStore((s) => s.removePlacedTile);
 
   useWakeLock(phase === 'playing');
+  useKeyboardControls(true);
 
   const [initialized, setInitialized] = useState(false);
   const [activeTileId, setActiveTileId] = useState<string | null>(null);


### PR DESCRIPTION
Enables crossword-style keyboard navigation for desktop play:
- Arrow keys navigate cursor around the board
- Letter keys (A-Z) place tiles from rack at cursor position
- Delete/Backspace remove tile at cursor and move backward
- Tab toggles horizontal/vertical cursor direction
- Escape clears cursor, Enter submits move

Cursor shown with pulsing green outline. Auto-advances after placing tiles, creating a fluid typing experience similar to crossword puzzles.