### PR TITLE
Remove dupe timer

### DIFF
--- a/packages/client/src/components/game/GameHeader.css
+++ b/packages/client/src/components/game/GameHeader.css
@@ -8,25 +8,12 @@
   position: relative;
 }
 
-.leave-btn {
+.game-header .back-btn {
   position: absolute;
   left: 4px;
   top: 50%;
   transform: translateY(-50%);
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 1.2rem;
-  padding: 4px 8px;
-  cursor: pointer;
-  border-radius: 4px;
-  line-height: 1;
   z-index: 1;
-}
-
-.leave-btn:hover {
-  color: var(--text);
-  background: rgba(255, 255, 255, 0.1);
 }
 
 .player-info {

--- a/packages/client/src/components/game/GameHeader.tsx
+++ b/packages/client/src/components/game/GameHeader.tsx
@@ -107,7 +107,7 @@ export function GameHeader({ isSpectator = false }: { isSpectator?: boolean }) {
 
   return (
     <div className="game-header">
-      <button className="leave-btn" onClick={handleLeave} title="Back to menu">
+      <button className="back-btn" onClick={handleLeave} title="Back to menu">
         &#x2190;
       </button>
       <div

--- a/packages/client/src/components/game/GameHeader.tsx
+++ b/packages/client/src/components/game/GameHeader.tsx
@@ -107,7 +107,6 @@ export function GameHeader({ isSpectator = false }: { isSpectator?: boolean }) {
 
   return (
     <div className="game-header">
-      <TimerDisplay isSpectator={isSpectator} />
       <button className="leave-btn" onClick={handleLeave} title="Back to menu">
         &#x2190;
       </button>

--- a/packages/client/src/components/tiles/TileRack.css
+++ b/packages/client/src/components/tiles/TileRack.css
@@ -23,8 +23,8 @@
 }
 
 .rack-tile {
-  width: 42px;
-  height: 42px;
+  width: 50px;
+  height: 50px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -70,23 +70,23 @@
 }
 
 .rack-tile-letter {
-  font-size: 1.2rem;
+  font-size: 1.4rem;
   font-weight: 700;
   line-height: 1;
 }
 
 .rack-tile-value {
   position: absolute;
-  bottom: 2px;
-  right: 3px;
-  font-size: 0.55rem;
+  bottom: 3px;
+  right: 4px;
+  font-size: 0.65rem;
   font-weight: 600;
   line-height: 1;
 }
 
 .drag-overlay-tile {
-  width: 42px;
-  height: 42px;
+  width: 50px;
+  height: 50px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/client/src/pages/GamePage.css
+++ b/packages/client/src/pages/GamePage.css
@@ -20,6 +20,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+}
+
+.loading-back-btn {
+  position: absolute;
+  top: 12px;
+  left: 12px;
 }
 
 .loading-text {

--- a/packages/client/src/pages/GamePage.css
+++ b/packages/client/src/pages/GamePage.css
@@ -25,8 +25,8 @@
 
 .loading-back-btn {
   position: absolute;
-  top: 12px;
-  left: 12px;
+  top: 8px;
+  left: 8px;
 }
 
 .loading-text {

--- a/packages/client/src/pages/GamePage.tsx
+++ b/packages/client/src/pages/GamePage.tsx
@@ -64,6 +64,7 @@ export function GamePage() {
 // ---------------------------------------------------------------------------
 
 function LocalGame() {
+  const navigate = useNavigate();
   const phase = useGameStore((s) => s.phase);
   const initLocalGame = useGameStore((s) => s.initLocalGame);
   const dictionaryLoaded = useGameStore((s) => s.dictionaryLoaded);
@@ -147,6 +148,9 @@ function LocalGame() {
   if (!dictionaryLoaded || phase === 'waiting') {
     return (
       <div className="game-loading">
+        <button className="back-btn loading-back-btn" onClick={() => navigate('/')}>
+          &#x2190;
+        </button>
         <div className="loading-text">Loading game...</div>
       </div>
     );
@@ -486,6 +490,9 @@ function OnlineGame({
   if (!gameReady) {
     return (
       <div className="game-loading">
+        <button className="back-btn loading-back-btn" onClick={handleAbandon}>
+          &#x2190;
+        </button>
         <div className="online-lobby">
           {connection.status === 'connecting' && <div className="loading-text">Connecting...</div>}
 

--- a/packages/client/src/pages/HomePage.css
+++ b/packages/client/src/pages/HomePage.css
@@ -107,24 +107,32 @@
 .settings-link {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 0.9rem;
+  justify-content: center;
+  gap: 10px;
+  background: var(--bg-card);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text);
+  font-size: 1.1rem;
+  font-weight: 600;
   cursor: pointer;
-  padding: 8px 16px;
-  border-radius: 6px;
+  padding: 14px 24px;
+  border-radius: 8px;
   margin-bottom: 24px;
+  min-width: 200px;
+  transition: all 0.15s ease;
 }
 
 .settings-link:hover {
-  color: var(--text);
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.1);
+  border-color: var(--accent);
+}
+
+.settings-link:active {
+  transform: scale(0.97);
 }
 
 .settings-icon {
-  font-size: 1.1rem;
+  font-size: 1.4rem;
 }
 
 .dev-qr {

--- a/packages/client/src/pages/SettingsPage.css
+++ b/packages/client/src/pages/SettingsPage.css
@@ -15,22 +15,6 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-.settings-back-btn {
-  background: none;
-  border: none;
-  color: var(--text-muted);
-  font-size: 1.2rem;
-  padding: 4px 8px;
-  cursor: pointer;
-  border-radius: 4px;
-  line-height: 1;
-}
-
-.settings-back-btn:hover {
-  color: var(--text);
-  background: rgba(255, 255, 255, 0.1);
-}
-
 .settings-title {
   font-size: 1.2rem;
   font-weight: 700;

--- a/packages/client/src/pages/SettingsPage.tsx
+++ b/packages/client/src/pages/SettingsPage.tsx
@@ -8,7 +8,7 @@ export function SettingsPage() {
   return (
     <div className="settings-page">
       <div className="settings-header">
-        <button className="settings-back-btn" onClick={() => navigate('/')}>
+        <button className="back-btn" onClick={() => navigate('/')}>
           &#x2190;
         </button>
         <h2 className="settings-title">Settings</h2>

--- a/packages/client/src/styles/global.css
+++ b/packages/client/src/styles/global.css
@@ -113,6 +113,36 @@ button:disabled {
   background: rgba(255, 255, 255, 0.1);
 }
 
+/* Back button - consistent across all screens */
+.back-btn {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.5rem;
+  /* Mobile-friendly touch target: minimum 44x44px */
+  min-width: 44px;
+  min-height: 44px;
+  padding: 8px;
+  cursor: pointer;
+  border-radius: 8px;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.back-btn:hover:not(:disabled) {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.back-btn:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.15);
+  transform: scale(0.95);
+}
+
 /* Light theme palette */
 [data-theme='light'] {
   /* Backgrounds */


### PR DESCRIPTION
This pull request primarily updates the tile rack UI to improve visibility and adds a new style for a loading page back button. The `TimerDisplay` component has also been removed from the game header.

**UI improvements for tile rack:**

* Increased the size of `.rack-tile` and `.drag-overlay-tile` from 42x42px to 50x50px, making the tiles larger and easier to see. [[1]](diffhunk://#diff-0468280d5e1189adead510002e0448c8b4b66c3624ece17bbf6ceb47583d1006L26-R27) [[2]](diffhunk://#diff-0468280d5e1189adead510002e0448c8b4b66c3624ece17bbf6ceb47583d1006L73-R89)
* Increased the font size for `.rack-tile-letter` and `.rack-tile-value`, and adjusted their positioning for better readability.

**Game header changes:**

* Removed the `TimerDisplay` component from the `GameHeader`, simplifying the header UI.

**Loading page enhancements:**

* Added a `.loading-back-btn` CSS class to position a back button absolutely in the loading screen, allowing users to navigate back more easily.