### PR TITLE
Replace Scrabble references with original BlitzTiles board layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What is this project?
 
-BlitzTiles is a Scrabble-like word game with blitz-chess style move clocks. It's a mobile-friendly web app where players can jump in without accounts, share a link to invite an opponent, and play with time pressure.
+BlitzTiles is a crossword-style word game with blitz-chess style move clocks. It's a mobile-friendly web app where players can jump in without accounts, share a link to invite an opponent, and play with time pressure.
 
 ## Architecture
 
@@ -88,7 +88,7 @@ Key files:
 
 ## Game rules quick reference
 
-- 15×15 board, standard Scrabble bonus layout (symmetric)
+- 15×15 board, BlitzTiles bonus layout (symmetric)
 - 100 tiles (standard distribution), 2 blanks (0 pts, wild)
 - Hand size: 7
 - First move must cover center square (7,7)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # BlitzTiles
 
-A Scrabble-like word game with blitz-chess style move clocks. Play fast-paced word battles with time pressure adding a strategic dimension beyond traditional word games.
+A crossword-style word game with blitz-chess style move clocks. Play fast-paced word battles with time pressure adding a strategic dimension beyond traditional word games.
 
 ## Features
 
-- 🎮 **Classic Scrabble Gameplay** — 15×15 board, standard tile distribution and bonus squares
+- 🎮 **Classic Word Gameplay** — 15×15 board, balanced tile distribution and bonus squares
 - ⏱️ **Blitz Mode Timers** — Move clocks add urgency and strategic depth
 - 📱 **Mobile-First Design** — Touch-optimized drag-and-drop interface
 - 🔗 **Instant Multiplayer** — No accounts needed, just share a link
@@ -85,7 +85,7 @@ packages/
 ## Game Rules
 
 - **Board**: 15×15 grid with bonus squares (DL, TL, DW, TW)
-- **Tiles**: 100 tiles total, standard Scrabble distribution
+- **Tiles**: 100 tiles with balanced letter distribution
 - **Hand Size**: 7 tiles
 - **Starting Move**: First word must cover center square (7,7)
 - **Valid Moves**: All placed tiles must form a single contiguous row or column, connected to existing tiles

--- a/packages/client/src/styles/global.css
+++ b/packages/client/src/styles/global.css
@@ -128,7 +128,7 @@ button:disabled {
   --accent: #9966cc;
   --accent-hover: #7744aa;
 
-  /* Tiles (dark on light - classic Scrabble) */
+  /* Tiles (dark on light - classic word game) */
   --tile-bg: #2c2c2c;
   --tile-text: #f5f5f5;
   --tile-border: #1a1a1a;

--- a/packages/shared/data/DICTIONARY_INFO.md
+++ b/packages/shared/data/DICTIONARY_INFO.md
@@ -1,20 +1,24 @@
 # Dictionary: ENABLE (Enhanced North American Benchmark LExicon)
 
 ## Source
+
 - Base list: ENABLE1 by Alan Beale & M. Cooper
 - License: **Public Domain** (no restrictions)
 - Original source: https://github.com/dolph/dictionary/blob/master/enable1.txt
 
 ## Modifications
-14 standard Scrabble short words added back that were missing from ENABLE:
+
+14 standard competitive word game short words added back that were missing from ENABLE:
+
 - 2-letter: AP, DA, EW, FE, GI, KI, OI, OK, OO, PO, QI, ZA
 - 3-letter: QIS, VIN
 
 These are all present in the official NWL (NASPA Word List) and are
-strategically important for Scrabble-style play (especially QI/QIS
+strategically important for competitive word game play (especially QI/QIS
 as the primary Q-without-U words).
 
 ## Stats
+
 - Word count: 172,837
 - Format: One uppercase word per line, gzipped
 - Uncompressed: ~1.7 MB

--- a/packages/shared/src/board.test.ts
+++ b/packages/shared/src/board.test.ts
@@ -62,12 +62,12 @@ describe('createEmptyBoard', () => {
     expect(board[7][7].bonus).toBe('DW');
   });
 
-  it('corner squares have TW bonus', () => {
+  it('TW squares are at edge positions', () => {
     const board = createEmptyBoard();
-    expect(board[0][0].bonus).toBe('TW');
-    expect(board[0][14].bonus).toBe('TW');
-    expect(board[14][0].bonus).toBe('TW');
-    expect(board[14][14].bonus).toBe('TW');
+    expect(board[0][4].bonus).toBe('TW');
+    expect(board[0][10].bonus).toBe('TW');
+    expect(board[14][4].bonus).toBe('TW');
+    expect(board[14][10].bonus).toBe('TW');
   });
 });
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,14 +1,14 @@
 /**
  * Game constants: tile distribution, bonus square map, and defaults.
  *
- * Tile distribution and bonus layout follow standard Scrabble rules.
+ * Tile distribution and bonus layout are original to BlitzTiles.
  * Board coordinates: row 0–14, col 0–14. Center is (7,7).
  */
 
 import type { BonusType, GameConfig } from './types.js';
 
 // ---------------------------------------------------------------------------
-// Tile distribution — 100 tiles total (standard Scrabble)
+// Tile distribution — 100 tiles total
 // ---------------------------------------------------------------------------
 
 /** [letter, count, pointValue]. Empty string = blank tile. */
@@ -49,7 +49,7 @@ export const CENTER = 7; // (7,7) is center square
 export const BINGO_BONUS = 50; // bonus for using all 7 tiles
 
 // ---------------------------------------------------------------------------
-// Bonus square map — standard 15×15 Scrabble layout
+// Bonus square map — BlitzTiles 15×15 layout
 // ---------------------------------------------------------------------------
 
 /**
@@ -59,81 +59,81 @@ export const BINGO_BONUS = 50; // bonus for using all 7 tiles
 function buildBonusMap(): BonusType[][] {
   const b: BonusType[][] = Array.from({ length: 15 }, () => Array(15).fill(null) as BonusType[]);
 
-  // Triple Word squares
+  // Triple Word squares (8)
   const tw: [number, number][] = [
-    [0, 0],
-    [0, 7],
-    [0, 14],
-    [7, 0],
-    [7, 14],
-    [14, 0],
-    [14, 7],
-    [14, 14],
+    [0, 4],
+    [0, 10],
+    [4, 0],
+    [4, 14],
+    [10, 0],
+    [10, 14],
+    [14, 4],
+    [14, 10],
   ];
 
-  // Double Word squares (including center)
+  // Double Word squares (17, including center)
   const dw: [number, number][] = [
-    [1, 1],
-    [2, 2],
-    [3, 3],
-    [4, 4],
-    [1, 13],
-    [2, 12],
-    [3, 11],
-    [4, 10],
-    [10, 4],
-    [11, 3],
-    [12, 2],
-    [13, 1],
-    [10, 10],
-    [11, 11],
-    [12, 12],
-    [13, 13],
     [7, 7], // center
-  ];
-
-  // Triple Letter squares
-  const tl: [number, number][] = [
-    [1, 5],
-    [1, 9],
-    [5, 1],
+    [1, 7],
+    [7, 13],
+    [13, 7],
+    [7, 1], // outer cross
+    [4, 7],
+    [7, 10],
+    [10, 7],
+    [7, 4], // inner cross
+    [3, 3],
+    [3, 11],
+    [11, 11],
+    [11, 3], // middle diamond
     [5, 5],
     [5, 9],
-    [5, 13],
-    [9, 1],
-    [9, 5],
     [9, 9],
-    [9, 13],
-    [13, 5],
-    [13, 9],
+    [9, 5], // inner diamond
   ];
 
-  // Double Letter squares
+  // Triple Letter squares (12)
+  const tl: [number, number][] = [
+    [0, 7],
+    [7, 14],
+    [14, 7],
+    [7, 0], // edge midpoints
+    [3, 5],
+    [5, 11],
+    [11, 9],
+    [9, 3], // mid-board ring A
+    [3, 9],
+    [9, 11],
+    [11, 5],
+    [5, 3], // mid-board ring B
+  ];
+
+  // Double Letter squares (24)
   const dl: [number, number][] = [
-    [0, 3],
-    [0, 11],
-    [2, 6],
-    [2, 8],
-    [3, 0],
-    [3, 7],
-    [3, 14],
-    [6, 2],
-    [6, 6],
-    [6, 8],
-    [6, 12],
-    [7, 3],
-    [7, 11],
-    [8, 2],
-    [8, 6],
-    [8, 8],
-    [8, 12],
-    [11, 0],
-    [11, 7],
-    [11, 14],
-    [12, 6],
-    [12, 8],
-    [14, 3],
-    [14, 11],
+    [1, 3],
+    [3, 13],
+    [13, 11],
+    [11, 1], // orbit 1
+    [1, 6],
+    [6, 13],
+    [13, 8],
+    [8, 1], // orbit 2
+    [2, 4],
+    [4, 12],
+    [12, 10],
+    [10, 2], // orbit 3
+    [4, 6],
+    [6, 10],
+    [10, 8],
+    [8, 4], // orbit 4
+    [6, 4],
+    [4, 8],
+    [8, 10],
+    [10, 6], // orbit 5
+    [5, 7],
+    [7, 9],
+    [9, 7],
+    [7, 5], // orbit 6
   ];
 
   for (const [r, c] of tw) b[r][c] = 'TW';

--- a/packages/shared/src/scoring.test.ts
+++ b/packages/shared/src/scoring.test.ts
@@ -49,23 +49,21 @@ describe('scoreTurn', () => {
   // -----------------------------------------------------------------------
 
   it('scores a simple word on non-bonus squares', () => {
-    // Place "CAT" horizontally at row 6, cols 6-8.
-    // Row 6, col 6 = DL, col 8 = DL — let's avoid those.
-    // Row 4, cols 5-7: (4,5) = null, (4,6) = null, (4,7) = null — all plain.
+    // Place "CAT" horizontally at row 0, cols 1-3 — all non-bonus in Blitz layout.
     const board = createEmptyBoard();
     const placedTiles: PlacedTile[] = [
-      makeTile('C', 3, 4, 5), // (4,5) = no bonus
-      makeTile('A', 1, 4, 6), // (4,6) = no bonus
-      makeTile('T', 1, 4, 7), // (4,7) = no bonus
+      makeTile('C', 3, 0, 1), // no bonus
+      makeTile('A', 1, 0, 2), // no bonus
+      makeTile('T', 1, 0, 3), // no bonus
     ];
 
     const formedWords = [
       {
         word: 'CAT',
         cells: [
-          { row: 4, col: 5 },
-          { row: 4, col: 6 },
-          { row: 4, col: 7 },
+          { row: 0, col: 1 },
+          { row: 0, col: 2 },
+          { row: 0, col: 3 },
         ],
       },
     ];
@@ -79,21 +77,21 @@ describe('scoreTurn', () => {
   // -----------------------------------------------------------------------
 
   it('applies double letter bonus to a newly placed tile', () => {
-    // (0,3) is DL. Place a tile worth 4 there.
+    // (1,3) is DL. Place a tile worth 4 there.
     const board = createEmptyBoard();
     const placedTiles: PlacedTile[] = [
-      makeTile('H', 4, 0, 3), // DL
-      makeTile('A', 1, 0, 4), // no bonus
-      makeTile('T', 1, 0, 5), // no bonus
+      makeTile('H', 4, 1, 3), // DL
+      makeTile('A', 1, 1, 4), // no bonus
+      makeTile('T', 1, 1, 5), // no bonus
     ];
 
     const formedWords = [
       {
         word: 'HAT',
         cells: [
-          { row: 0, col: 3 },
-          { row: 0, col: 4 },
-          { row: 0, col: 5 },
+          { row: 1, col: 3 },
+          { row: 1, col: 4 },
+          { row: 1, col: 5 },
         ],
       },
     ];
@@ -107,21 +105,21 @@ describe('scoreTurn', () => {
   // -----------------------------------------------------------------------
 
   it('applies triple letter bonus to a newly placed tile', () => {
-    // (1,5) is TL. Place a tile worth 4 there.
+    // (3,5) is TL. Place a tile worth 4 there.
     const board = createEmptyBoard();
     const placedTiles: PlacedTile[] = [
-      makeTile('A', 1, 1, 4), // no bonus
-      makeTile('F', 4, 1, 5), // TL
-      makeTile('T', 1, 1, 6), // no bonus
+      makeTile('A', 1, 3, 4), // no bonus
+      makeTile('F', 4, 3, 5), // TL
+      makeTile('T', 1, 3, 6), // no bonus
     ];
 
     const formedWords = [
       {
         word: 'AFT',
         cells: [
-          { row: 1, col: 4 },
-          { row: 1, col: 5 },
-          { row: 1, col: 6 },
+          { row: 3, col: 4 },
+          { row: 3, col: 5 },
+          { row: 3, col: 6 },
         ],
       },
     ];
@@ -163,19 +161,19 @@ describe('scoreTurn', () => {
   // -----------------------------------------------------------------------
 
   it('applies triple word bonus when a new tile is on a TW square', () => {
-    // (0,0) is TW.
+    // (0,4) is TW.
     const board = createEmptyBoard();
     const placedTiles: PlacedTile[] = [
-      makeTile('G', 2, 0, 0), // TW
-      makeTile('O', 1, 0, 1), // no bonus
+      makeTile('G', 2, 0, 4), // TW
+      makeTile('O', 1, 0, 5), // no bonus
     ];
 
     const formedWords = [
       {
         word: 'GO',
         cells: [
-          { row: 0, col: 0 },
-          { row: 0, col: 1 },
+          { row: 0, col: 4 },
+          { row: 0, col: 5 },
         ],
       },
     ];
@@ -189,52 +187,43 @@ describe('scoreTurn', () => {
   // -----------------------------------------------------------------------
 
   it('stacks multiple word bonuses multiplicatively', () => {
-    // (1,1) is DW and (4,4) is DW. Place a diagonal? No, Scrabble is rows/cols.
-    // We need a word that crosses two DW squares in the same row or column.
-    // DW squares on the diagonal: (1,1), (2,2), (3,3), (4,4).
-    // A column isn't going to hit two of those. Let's think...
-    //
-    // Actually, for a horizontal word: row 7 has DW at (7,7). Row 0 has TW at
-    // (0,0) and (0,7). A word from (0,0) to (0,7) would cross two TW squares:
-    // that's 8 letters long.
-    //
-    // Simpler: place a word at row 0 crossing (0,0) TW and (0,7) TW.
-    // That requires an 8-letter word. Let's just do it with tiles.
+    // We need a word that crosses two TW squares in the same row.
+    // Row 0 has TW at (0,4) and (0,10), plus TL at (0,7).
+    // Place a 7-tile word from col 4 to col 10.
     const board = createEmptyBoard();
 
-    // 8 tiles across row 0, cols 0–7
+    // 7 tiles across row 0, cols 4–10
     const placedTiles: PlacedTile[] = [
-      makeTile('A', 1, 0, 0), // TW
-      makeTile('B', 3, 0, 1),
-      makeTile('C', 3, 0, 2),
-      makeTile('D', 2, 0, 3), // DL → letter bonus, not word bonus
-      makeTile('E', 1, 0, 4),
-      makeTile('F', 4, 0, 5),
-      makeTile('G', 2, 0, 6),
-      makeTile('H', 4, 0, 7), // TW
+      makeTile('A', 1, 0, 4), // TW
+      makeTile('B', 3, 0, 5),
+      makeTile('C', 3, 0, 6),
+      makeTile('D', 2, 0, 7), // TL → letter bonus (2×3=6), not word bonus
+      makeTile('E', 1, 0, 8),
+      makeTile('F', 4, 0, 9),
+      makeTile('G', 2, 0, 10), // TW
     ];
 
     const formedWords = [
       {
-        word: 'ABCDEFGH',
+        word: 'ABCDEFG',
         cells: [
-          { row: 0, col: 0 },
-          { row: 0, col: 1 },
-          { row: 0, col: 2 },
-          { row: 0, col: 3 },
           { row: 0, col: 4 },
           { row: 0, col: 5 },
           { row: 0, col: 6 },
           { row: 0, col: 7 },
+          { row: 0, col: 8 },
+          { row: 0, col: 9 },
+          { row: 0, col: 10 },
         ],
       },
     ];
 
-    // Letter scores: A=1, B=3, C=3, D=2×2(DL)=4, E=1, F=4, G=2, H=4
-    // Sum = 1+3+3+4+1+4+2+4 = 22
-    // Word multipliers: TW at (0,0) × TW at (0,7) = 3×3 = 9
-    // 22 × 9 = 198
-    expect(scoreTurn(board, placedTiles, formedWords)).toBe(198);
+    // Letter scores: A=1, B=3, C=3, D=2×3(TL)=6, E=1, F=4, G=2
+    // Sum = 1+3+3+6+1+4+2 = 20
+    // Word multipliers: TW at (0,4) × TW at (0,10) = 3×3 = 9
+    // 20 × 9 = 180
+    // +50 bingo bonus (7 tiles placed) = 230
+    expect(scoreTurn(board, placedTiles, formedWords)).toBe(230);
   });
 
   // -----------------------------------------------------------------------
@@ -242,19 +231,19 @@ describe('scoreTurn', () => {
   // -----------------------------------------------------------------------
 
   it('blank tile on a letter bonus square still scores 0', () => {
-    // (0,3) is DL. Place a blank there (value 0).
+    // (1,3) is DL. Place a blank there (value 0).
     const board = createEmptyBoard();
     const placedTiles: PlacedTile[] = [
-      makeTile('A', 0, 0, 3, true), // blank on DL — value stays 0
-      makeTile('T', 1, 0, 4),
+      makeTile('A', 0, 1, 3, true), // blank on DL — value stays 0
+      makeTile('T', 1, 1, 4),
     ];
 
     const formedWords = [
       {
         word: 'AT',
         cells: [
-          { row: 0, col: 3 },
-          { row: 0, col: 4 },
+          { row: 1, col: 3 },
+          { row: 1, col: 4 },
         ],
       },
     ];
@@ -270,35 +259,35 @@ describe('scoreTurn', () => {
   it('adds bingo bonus when exactly 7 tiles are placed', () => {
     const board = createEmptyBoard();
 
-    // Place 7 tiles across row 4, cols 1–7 (all non-bonus squares).
-    // (4,4) is DW though, so the word will get doubled. Let's account for that.
+    // Place 7 tiles across row 1, cols 4–10.
+    // (1,6) is DL and (1,7) is DW. Account for both.
     const placedTiles: PlacedTile[] = [
-      makeTile('T', 1, 4, 1),
-      makeTile('E', 1, 4, 2),
-      makeTile('S', 1, 4, 3),
-      makeTile('T', 1, 4, 4), // DW
-      makeTile('I', 1, 4, 5),
-      makeTile('N', 1, 4, 6),
-      makeTile('G', 2, 4, 7),
+      makeTile('T', 1, 1, 4),
+      makeTile('E', 1, 1, 5),
+      makeTile('S', 1, 1, 6), // DL
+      makeTile('T', 1, 1, 7), // DW
+      makeTile('I', 1, 1, 8),
+      makeTile('N', 1, 1, 9),
+      makeTile('G', 2, 1, 10),
     ];
 
     const formedWords = [
       {
         word: 'TESTING',
         cells: [
-          { row: 4, col: 1 },
-          { row: 4, col: 2 },
-          { row: 4, col: 3 },
-          { row: 4, col: 4 },
-          { row: 4, col: 5 },
-          { row: 4, col: 6 },
-          { row: 4, col: 7 },
+          { row: 1, col: 4 },
+          { row: 1, col: 5 },
+          { row: 1, col: 6 },
+          { row: 1, col: 7 },
+          { row: 1, col: 8 },
+          { row: 1, col: 9 },
+          { row: 1, col: 10 },
         ],
       },
     ];
 
-    // Letter sum: 1+1+1+1+1+1+2 = 8, ×2 (DW at 4,4) = 16, +50 bingo = 66
-    expect(scoreTurn(board, placedTiles, formedWords)).toBe(66);
+    // Letter sum: 1+1+1×2(DL)+1+1+1+2 = 9, ×2 (DW at 1,7) = 18, +50 bingo = 68
+    expect(scoreTurn(board, placedTiles, formedWords)).toBe(68);
   });
 
   // -----------------------------------------------------------------------
@@ -307,14 +296,14 @@ describe('scoreTurn', () => {
 
   it('does not add bingo bonus when fewer than 7 tiles are placed', () => {
     const board = createEmptyBoard();
-    const placedTiles: PlacedTile[] = [makeTile('A', 1, 4, 5), makeTile('T', 1, 4, 6)];
+    const placedTiles: PlacedTile[] = [makeTile('A', 1, 2, 1), makeTile('T', 1, 2, 2)];
 
     const formedWords = [
       {
         word: 'AT',
         cells: [
-          { row: 4, col: 5 },
-          { row: 4, col: 6 },
+          { row: 2, col: 1 },
+          { row: 2, col: 2 },
         ],
       },
     ];
@@ -328,45 +317,40 @@ describe('scoreTurn', () => {
   // -----------------------------------------------------------------------
 
   it('sums scores from multiple formed words (main + cross words)', () => {
-    // Existing word "AT" on row 4, cols 5-6 (already on board).
-    // New tile "C" placed at (3, 5) — forms "CAT" vertically down col 5
-    //   and maybe "CA" isn't a word but let's just test scoring logic.
-    // We also form the cross word by itself.
+    // Existing word "AT" on row 3, cols 1-2 (already on board, all non-bonus).
     const board = createEmptyBoard();
 
     // Place existing tiles on the board.
-    board[4][5].tile = makeTile('A', 1, 4, 5);
-    board[4][6].tile = makeTile('T', 1, 4, 6);
+    board[3][1].tile = makeTile('A', 1, 3, 1);
+    board[3][2].tile = makeTile('T', 1, 3, 2);
 
-    // Newly placed tiles this turn: just the C at (3,5) — no bonus at (3,5).
-    // Actually (3,5) is null in BONUS_MAP? Let me check: row 3 DL positions
-    // are (3,0), (3,7), (3,14). (3,5) has no bonus. Good.
-    const placedTiles: PlacedTile[] = [makeTile('C', 3, 3, 5), makeTile('O', 1, 3, 6)];
+    // Newly placed tiles: C at (2,1) and O at (2,2) — both non-bonus.
+    const placedTiles: PlacedTile[] = [makeTile('C', 3, 2, 1), makeTile('O', 1, 2, 2)];
 
-    // Two formed words:
-    // 1) "CO" horizontally at row 3, cols 5-6 (both newly placed)
-    // 2) "CA" vertically at col 5, rows 3-4 (C is new, A is existing)
-    // 3) "OT" vertically at col 6, rows 3-4 (O is new, T is existing)
+    // Three formed words:
+    // 1) "CO" horizontally at row 2, cols 1-2 (both newly placed)
+    // 2) "CA" vertically at col 1, rows 2-3 (C is new, A is existing)
+    // 3) "OT" vertically at col 2, rows 2-3 (O is new, T is existing)
     const formedWords = [
       {
         word: 'CO',
         cells: [
-          { row: 3, col: 5 },
-          { row: 3, col: 6 },
+          { row: 2, col: 1 },
+          { row: 2, col: 2 },
         ],
       },
       {
         word: 'CA',
         cells: [
-          { row: 3, col: 5 },
-          { row: 4, col: 5 },
+          { row: 2, col: 1 },
+          { row: 3, col: 1 },
         ],
       },
       {
         word: 'OT',
         cells: [
-          { row: 3, col: 6 },
-          { row: 4, col: 6 },
+          { row: 2, col: 2 },
+          { row: 3, col: 2 },
         ],
       },
     ];
@@ -383,22 +367,22 @@ describe('scoreTurn', () => {
   // -----------------------------------------------------------------------
 
   it('does not apply bonuses to existing tiles on bonus squares', () => {
-    // Place an existing tile on (0,3) which is DL. Then form a word through
+    // Place an existing tile on (1,3) which is DL. Then form a word through
     // it with a new tile. The existing tile should NOT get the DL bonus again.
     const board = createEmptyBoard();
 
-    // "H" already on board at (0,3) — DL square.
-    board[0][3].tile = makeTile('H', 4, 0, 3);
+    // "H" already on board at (1,3) — DL square.
+    board[1][3].tile = makeTile('H', 4, 1, 3);
 
-    // New tile "I" at (0,4) — no bonus.
-    const placedTiles: PlacedTile[] = [makeTile('I', 1, 0, 4)];
+    // New tile "I" at (1,4) — no bonus.
+    const placedTiles: PlacedTile[] = [makeTile('I', 1, 1, 4)];
 
     const formedWords = [
       {
         word: 'HI',
         cells: [
-          { row: 0, col: 3 },
-          { row: 0, col: 4 },
+          { row: 1, col: 3 },
+          { row: 1, col: 4 },
         ],
       },
     ];

--- a/packages/shared/src/words.test.ts
+++ b/packages/shared/src/words.test.ts
@@ -157,7 +157,7 @@ describe('loadCompressedDictionary', () => {
     const trie = await loadCompressedDictionary(new Uint8Array(gzipped));
     expect(trie.has('HELLO')).toBe(true);
     expect(trie.has('WORLD')).toBe(true);
-    expect(trie.has('SCRABBLE')).toBe(true);
+    expect(trie.has('PUZZLE')).toBe(true);
     expect(trie.has('ZYZZYVA')).toBe(true);
   });
 

--- a/plan.md
+++ b/plan.md
@@ -1,235 +1,235 @@
-Plan to implement                                                                                                                              │
-│                                                                                                                                                │
-│ BlitzTiles Implementation Plan                                                                                                                 │
-│                                                                                                                                                │
-│ Context                                                                                                                                        │
-│                                                                                                                                                │
-│ BlitzTiles is a Scrabble-like word game with blitz-chess style move clocks, built as a mobile-friendly web app. Players can jump in without    │
-│ accounts, share a link to invite an opponent, and play with time pressure adding a strategic dimension beyond traditional word games. The      │
-│ project is greenfield — no code exists yet.                                                                                                    │
-│                                                                                                                                                │
-│ ---                                                                                                                                            │
-│ Architecture Decisions                                                                                                                         │
-│                                                                                                                                                │
-│ Stack                                                                                                                                          │
-│                                                                                                                                                │
-│ - Frontend: React + TypeScript + Vite                                                                                                          │
-│ - State management: Zustand (minimal boilerplate, ~1KB)                                                                                        │
-│ - Drag-and-drop: @dnd-kit (first-class touch support, ~10KB)                                                                                   │
-│ - Multiplayer server: PartyKit (Cloudflare Durable Objects) — each game room is a Durable Object with WebSocket connections. Handles room      │
-│ management, reconnection, and edge deployment with zero server provisioning. Free tier covers 100K requests/day.                               │
-│ - Networking client: partysocket (auto-reconnection built in)                                                                                  │
-│ - Routing: react-router-dom                                                                                                                    │
-│ - Testing: Vitest                                                                                                                              │
-│ - Dictionary: ENABLE word list (~172K words, public domain — safe for open source)                                                             │
-│                                                                                                                                                │
-│ Why PartyKit over alternatives                                                                                                                 │
-│                                                                                                                                                │
-│ - vs raw WebSocket server: No server to provision/pay for. No connection pooling. Rooms are first-class.                                       │
-│ - vs WebRTC: Eliminates NAT traversal complexity. Server-authoritative validation and timer sync are trivial (impossible with pure P2P).       │
-│ - vs Firebase/Supabase: Lower latency (raw WebSocket vs polling-based realtime). No heavy SDK. No database for ephemeral game state.           │
-│                                                                                                                                                │
-│ Server-authoritative game state                                                                                                                │
-│                                                                                                                                                │
-│ The server owns all game state: board, tile bag, hands, scores, and timers. Clients send intents (SUBMIT_MOVE, PASS, EXCHANGE), the server     │
-│ validates, updates state, and broadcasts. This prevents cheating and makes timer sync trivial. Clients do optimistic UI for tile placement     │
-│ (before submit) but never advance game state locally.                                                                                          │
-│                                                                                                                                                │
-│ Timer sync                                                                                                                                     │
-│                                                                                                                                                │
-│ - Server records turnStartTimestamp on each turn                                                                                               │
-│ - Server schedules a Durable Object alarm() for when time would expire                                                                         │
-│ - Clients display a locally-ticking countdown, reconciled on every server message and periodic TIMER_SYNC pings (every 5s)                     │
-│ - Player disconnects don't pause the clock                                                                                                     │
-│                                                                                                                                                │
-│ ---                                                                                                                                            │
-│ Project Structure                                                                                                                              │
-│                                                                                                                                                │
-│ blitztiles/                                                                                                                                    │
-│ ├── package.json                  # pnpm workspace root                                                                                        │
-│ ├── tsconfig.base.json                                                                                                                         │
-│ ├── packages/                                                                                                                                  │
-│ │   ├── shared/                   # Shared types + pure game logic                                                                             │
-│ │   │   └── src/                                                                                                                               │
-│ │   │       ├── types.ts          # GameState, Tile, PlayerState, messages                                                                     │
-│ │   │       ├── constants.ts      # Tile distribution, board bonuses, defaults                                                                 │
-│ │   │       ├── board.ts          # Placement validation, word extraction                                                                      │
-│ │   │       ├── scoring.ts        # Score calculation with bonus squares                                                                       │
-│ │   │       ├── tileBag.ts        # Tile bag: create, draw, exchange                                                                           │
-│ │   │       ├── words.ts          # Trie implementation for word lookup                                                                        │
-│ │   │       └── gameEngine.ts     # Pure state machine: submitMove, pass, exchange                                                             │
-│ │   ├── client/                   # React + Vite frontend                                                                                      │
-│ │   │   └── src/                                                                                                                               │
-│ │   │       ├── pages/                                                                                                                         │
-│ │   │       │   ├── HomePage.tsx        # Create/Join game                                                                                     │
-│ │   │       │   └── GamePage.tsx        # Main game view                                                                                       │
-│ │   │       ├── components/                                                                                                                    │
-│ │   │       │   ├── board/                                                                                                                     │
-│ │   │       │   │   ├── GameBoard.tsx   # 15x15 CSS Grid + DnD context                                                                         │
-│ │   │       │   │   └── BoardCell.tsx   # Single cell (droppable)                                                                              │
-│ │   │       │   ├── tiles/                                                                                                                     │
-│ │   │       │   │   ├── TileRack.tsx    # Player's 7-tile hand                                                                                 │
-│ │   │       │   │   └── DraggableTile.tsx                                                                                                      │
-│ │   │       │   └── game/                                                                                                                      │
-│ │   │       │       ├── GameHeader.tsx  # Scores + timers                                                                                      │
-│ │   │       │       ├── TimerDisplay.tsx                                                                                                       │
-│ │   │       │       ├── GameControls.tsx                                                                                                       │
-│ │   │       │       ├── GameOverModal.tsx                                                                                                      │
-│ │   │       │       └── BlankTileModal.tsx                                                                                                     │
-│ │   │       ├── hooks/                                                                                                                         │
-│ │   │       │   ├── useGameStore.ts      # Zustand store                                                                                       │
-│ │   │       │   ├── useGameConnection.ts # PartySocket connection                                                                              │
-│ │   │       │   └── useTimer.ts          # Client-side timer tick                                                                              │
-│ │   │       └── styles/                                                                                                                        │
-│ │   └── server/                   # PartyKit server                                                                                            │
-│ │       ├── src/                                                                                                                               │
-│ │       │   ├── game.ts           # Main PartyKit server class                                                                                 │
-│ │       │   ├── timerManager.ts   # Timer tracking + alarm scheduling                                                                          │
-│ │       │   └── dictionary.ts     # Dictionary loading + Trie                                                                                  │
-│ │       └── data/                                                                                                                              │
-│ │           └── enable.txt        # ENABLE word list                                                                                           │
-│                                                                                                                                                │
-│ ---                                                                                                                                            │
-│ Phased Implementation                                                                                                                          │
-│                                                                                                                                                │
-│ Phase 1: Foundation + Shared Core (sequential)                                                                                                 │
-│                                                                                                                                                │
-│ Scaffold the project, define the shared contract, and implement all core game logic. This phase must complete first because both client and    │
-│ server depend on it.                                                                                                                           │
-│                                                                                                                                                │
-│ Scaffolding:                                                                                                                                   │
-│ - Initialize pnpm workspace with shared, client, server packages                                                                               │
-│ - Scaffold React app with Vite (client/)                                                                                                       │
-│ - Scaffold PartyKit server (server/)                                                                                                           │
-│ - tsconfig.base.json with shared TypeScript config                                                                                             │
-│                                                                                                                                                │
-│ Shared types (shared/src/types.ts):                                                                                                            │
-│ - All TypeScript types: Tile, PlacedTile, GameState, PlayerState                                                                               │
-│ - ClientMessage / ServerMessage discriminated unions (the network contract)                                                                    │
-│ - GameConfig (timer mode, duration, dictionary choice)                                                                                         │
-│                                                                                                                                                │
-│ Shared constants (shared/src/constants.ts):                                                                                                    │
-│ - Tile distribution (100 tiles, letters/counts/values)                                                                                         │
-│ - 15x15 bonus square map (DL/TL/DW/TW)                                                                                                         │
-│ - Game config defaults                                                                                                                         │
-│                                                                                                                                                │
-│ Shared game logic (pure functions, fully tested):                                                                                              │
-│ - shared/src/tileBag.ts — createTileBag(), drawTiles(), exchangeTiles()                                                                        │
-│ - shared/src/words.ts — Trie class with insert() and has(), loadDictionary() parser                                                            │
-│ - shared/src/board.ts — isValidPlacement(), getFormedWords()                                                                                   │
-│ - shared/src/scoring.ts — scoreTurn() with DL/TL/DW/TW bonuses, 50-point all-tiles bonus                                                       │
-│ - shared/src/gameEngine.ts — pure state machine: createGame(), submitMove(), passTurn(), exchangeTiles(), checkEndConditions()                 │
-│ - Unit tests for all of the above                                                                                                              │
-│                                                                                                                                                │
-│ ---                                                                                                                                            │
-│ Phase 2: Client + Server in Parallel (via subagents)                                                                                           │
-│                                                                                                                                                │
-│ Once Phase 1 is complete, client and server can be built simultaneously since they both depend only on the shared package.                     │
-│                                                                                                                                                │
-│ Phase 2A: Client (subagent A)                                                                                                                  │
-│                                                                                                                                                │
-│ Build the full client UI with local hot-seat play, then wire up networking.                                                                    │
-│                                                                                                                                                │
-│ Board + Tiles (static rendering):                                                                                                              │
-│ - GameBoard.tsx + BoardCell.tsx — 15x15 CSS Grid with bonus square colors                                                                      │
-│ - DraggableTile.tsx + TileRack.tsx — tile visuals (letter + point value), 7-tile rack                                                          │
-│ - Responsive layout: board fills width on mobile, side-by-side on desktop                                                                      │
-│                                                                                                                                                │
-│ Drag-and-drop + mobile input:                                                                                                                  │
-│ - @dnd-kit integration: DndContext in board, useDraggable on tiles, useDroppable on cells                                                      │
-│ - Drag overlay follows pointer/finger (CSS transforms, GPU-accelerated)                                                                        │
-│ - Tap-to-place as primary mobile input: tap tile (highlights) → tap cell (places)                                                              │
-│ - Pinch-to-zoom wrapper on the board                                                                                                           │
-│ - Visual feedback: cell highlight on drag-over, snap animation, tile lift effect                                                               │
-│                                                                                                                                                │
-│ Local hot-seat play:                                                                                                                           │
-│ - useGameStore.ts — Zustand store driving local play via shared gameEngine                                                                     │
-│ - GamePage.tsx — hot-seat mode: hands swap on turn change                                                                                      │
-│ - GameControls.tsx — Submit, Pass, Exchange, Shuffle buttons                                                                                   │
-│ - GameHeader.tsx + ScoreDisplay.tsx — player names and scores                                                                                  │
-│                                                                                                                                                │
-│ Timer display:                                                                                                                                 │
-│ - TimerDisplay.tsx — both clocks, active clock pulses, color shifts white→yellow→red                                                           │
-│ - useTimer.ts — requestAnimationFrame countdown, MM:SS format (SS.T under 10s)                                                                 │
-│                                                                                                                                                │
-│ Networking hookup (after server is ready):                                                                                                     │
-│ - useGameConnection.ts — PartySocket hook: connect to room, translate server messages to Zustand updates                                       │
-│ - HomePage.tsx — create game (pick timer mode + duration), join game (enter code or paste link)                                                │
-│                                                                                                                                                │
-│ Modals + polish:                                                                                                                               │
-│ - GameOverModal.tsx — final scores, rematch button                                                                                             │
-│ - BlankTileModal.tsx — letter picker for blank tiles                                                                                           │
-│ - Exchange tiles modal                                                                                                                         │
-│                                                                                                                                                │
-│ Phase 2B: Server (subagent B)                                                                                                                  │
-│                                                                                                                                                │
-│ Build the PartyKit server that wraps shared game logic with networking, auth, and timers.                                                      │
-│                                                                                                                                                │
-│ Core server:                                                                                                                                   │
-│ - server/src/game.ts — PartyKit server class:                                                                                                  │
-│   - onConnect: assign player index (0 or 1), send waiting state or start game when 2 connected                                                 │
-│   - onMessage: parse ClientMessage, validate via shared gameEngine, broadcast ServerMessage                                                    │
-│   - onClose: mark disconnected (timer keeps running)                                                                                           │
-│   - alarm(): handle timer expiry                                                                                                               │
-│ - Security: filter GameState before sending — each player only gets their own hand tiles, opponent hand sent as count only                     │
-│                                                                                                                                                │
-│ Dictionary:                                                                                                                                    │
-│ - server/src/dictionary.ts — load ENABLE word list into Trie on Durable Object startup, cache in memory                                        │
-│                                                                                                                                                │
-│ Timer manager:                                                                                                                                 │
-│ - server/src/timerManager.ts — record turn start, compute elapsed on move, schedule DO alarms                                                  │
-│ - Sudden Death: alarm fires → game over, timed-out player loses                                                                                │
-│ - Time Penalty: track cumulative time, compute point deductions at game end                                                                    │
-│ - Periodic TIMER_SYNC messages every 5s during active play                                                                                     │
-│                                                                                                                                                │
-│ Room management:                                                                                                                               │
-│ - Generate 4-char room codes                                                                                                                   │
-│ - Handle reconnection (match player by ID in WebSocket URL query param)                                                                        │
-│ - Rematch flow: same room, swap turn order                                                                                                     │
-│                                                                                                                                                │
-│ ---                                                                                                                                            │
-│ Phase 3: Integration + Polish (sequential)                                                                                                     │
-│                                                                                                                                                │
-│ Converge the two workstreams and add final polish.                                                                                             │
-│                                                                                                                                                │
-│ - Wire useGameConnection.ts to server (swap local engine for network messages)                                                                 │
-│ - End-to-end testing: two browser tabs, create game → join → play → game over → rematch                                                        │
-│ - Animations: tile snap (scale bounce), score popup (floating "+42"), word highlight                                                           │
-│ - Sound effects via Web Audio API (tile place, word accepted/rejected, timer warnings)                                                         │
-│ - Move history panel (collapsible)                                                                                                             │
-│ - Connection status indicator                                                                                                                  │
-│ - Dark mode default, clean modern aesthetic                                                                                                    │
-│                                                                                                                                                │
-│ Phase 4: Testing + Deployment                                                                                                                  │
-│                                                                                                                                                │
-│ - Comprehensive unit tests for shared/ (board edge cases, scoring combos, full game simulations)                                               │
-│ - Component tests with React Testing Library                                                                                                   │
-│ - Server integration tests (simulated 2-client game flows)                                                                                     │
-│ - Deploy client to Cloudflare Pages                                                                                                            │
-│ - Deploy server via PartyKit CLI / wrangler                                                                                                    │
-│ - GitHub Actions CI: lint, typecheck, test, build, deploy                                                                                      │
-│                                                                                                                                                │
-│ ---                                                                                                                                            │
-│ Key Game Rules Reference                                                                                                                       │
-│                                                                                                                                                │
-│ - Board: 15x15 grid with standard bonus square layout (symmetric)                                                                              │
-│ - Tiles: 100 total (standard Scrabble distribution), 2 blanks (0 points, represent any letter)                                                 │
-│ - Hand size: 7 tiles                                                                                                                           │
-│ - First move: must cover the center square                                                                                                     │
-│ - Placement rules: tiles must form a single row or column, be contiguous (gaps filled by existing tiles), connect to at least one existing     │
-│ tile                                                                                                                                           │
-│ - Scoring: letter values × letter bonuses + word bonuses. Bonuses apply only on the turn placed. 50-point bonus for using all 7 tiles.         │
-│ - End conditions: (a) player uses last tile + bag empty (bonus = sum of opponent's hand), (b) both players pass consecutively, (c) timer       │
-│ expires (mode-dependent), (d) resignation                                                                                                      │
-│                                                                                                                                                │
-│ Verification                                                                                                                                   │
-│                                                                                                                                                │
-│ After each phase, verify by:                                                                                                                   │
-│ 1. Phase 1: Run pnpm test — all shared game logic unit tests pass. Game engine can simulate a full game programmatically.                      │
-│ 2. Phase 2A: Board renders 225 cells with correct bonus colors on mobile and desktop. Tiles can be placed via drag-and-drop (desktop) and      │
-│ tap-to-place (mobile). Local hot-seat game plays to completion with correct scoring.                                                           │
-│ 3. Phase 2B: Server starts, accepts two WebSocket connections, validates moves, broadcasts state. Timer alarms fire correctly. Can be tested   │
-│ with a simple WebSocket client script.                                                                                                         │
-│ 4. Phase 3: Open two browser tabs, create a game in one, join via code in the other, play a full networked game to completion. Timers work.    │
-│ Rematch works. Animations and sounds play.                                                                                                     │
+Plan to implement │
+│ │
+│ BlitzTiles Implementation Plan │
+│ │
+│ Context │
+│ │
+│ BlitzTiles is a crossword-style word game with blitz-chess style move clocks, built as a mobile-friendly web app. Players can jump in without │
+│ accounts, share a link to invite an opponent, and play with time pressure adding a strategic dimension beyond traditional word games. The │
+│ project is greenfield — no code exists yet. │
+│ │
+│ --- │
+│ Architecture Decisions │
+│ │
+│ Stack │
+│ │
+│ - Frontend: React + TypeScript + Vite │
+│ - State management: Zustand (minimal boilerplate, ~1KB) │
+│ - Drag-and-drop: @dnd-kit (first-class touch support, ~10KB) │
+│ - Multiplayer server: PartyKit (Cloudflare Durable Objects) — each game room is a Durable Object with WebSocket connections. Handles room │
+│ management, reconnection, and edge deployment with zero server provisioning. Free tier covers 100K requests/day. │
+│ - Networking client: partysocket (auto-reconnection built in) │
+│ - Routing: react-router-dom │
+│ - Testing: Vitest │
+│ - Dictionary: ENABLE word list (~172K words, public domain — safe for open source) │
+│ │
+│ Why PartyKit over alternatives │
+│ │
+│ - vs raw WebSocket server: No server to provision/pay for. No connection pooling. Rooms are first-class. │
+│ - vs WebRTC: Eliminates NAT traversal complexity. Server-authoritative validation and timer sync are trivial (impossible with pure P2P). │
+│ - vs Firebase/Supabase: Lower latency (raw WebSocket vs polling-based realtime). No heavy SDK. No database for ephemeral game state. │
+│ │
+│ Server-authoritative game state │
+│ │
+│ The server owns all game state: board, tile bag, hands, scores, and timers. Clients send intents (SUBMIT_MOVE, PASS, EXCHANGE), the server │
+│ validates, updates state, and broadcasts. This prevents cheating and makes timer sync trivial. Clients do optimistic UI for tile placement │
+│ (before submit) but never advance game state locally. │
+│ │
+│ Timer sync │
+│ │
+│ - Server records turnStartTimestamp on each turn │
+│ - Server schedules a Durable Object alarm() for when time would expire │
+│ - Clients display a locally-ticking countdown, reconciled on every server message and periodic TIMER_SYNC pings (every 5s) │
+│ - Player disconnects don't pause the clock │
+│ │
+│ --- │
+│ Project Structure │
+│ │
+│ blitztiles/ │
+│ ├── package.json # pnpm workspace root │
+│ ├── tsconfig.base.json │
+│ ├── packages/ │
+│ │ ├── shared/ # Shared types + pure game logic │
+│ │ │ └── src/ │
+│ │ │ ├── types.ts # GameState, Tile, PlayerState, messages │
+│ │ │ ├── constants.ts # Tile distribution, board bonuses, defaults │
+│ │ │ ├── board.ts # Placement validation, word extraction │
+│ │ │ ├── scoring.ts # Score calculation with bonus squares │
+│ │ │ ├── tileBag.ts # Tile bag: create, draw, exchange │
+│ │ │ ├── words.ts # Trie implementation for word lookup │
+│ │ │ └── gameEngine.ts # Pure state machine: submitMove, pass, exchange │
+│ │ ├── client/ # React + Vite frontend │
+│ │ │ └── src/ │
+│ │ │ ├── pages/ │
+│ │ │ │ ├── HomePage.tsx # Create/Join game │
+│ │ │ │ └── GamePage.tsx # Main game view │
+│ │ │ ├── components/ │
+│ │ │ │ ├── board/ │
+│ │ │ │ │ ├── GameBoard.tsx # 15x15 CSS Grid + DnD context │
+│ │ │ │ │ └── BoardCell.tsx # Single cell (droppable) │
+│ │ │ │ ├── tiles/ │
+│ │ │ │ │ ├── TileRack.tsx # Player's 7-tile hand │
+│ │ │ │ │ └── DraggableTile.tsx │
+│ │ │ │ └── game/ │
+│ │ │ │ ├── GameHeader.tsx # Scores + timers │
+│ │ │ │ ├── TimerDisplay.tsx │
+│ │ │ │ ├── GameControls.tsx │
+│ │ │ │ ├── GameOverModal.tsx │
+│ │ │ │ └── BlankTileModal.tsx │
+│ │ │ ├── hooks/ │
+│ │ │ │ ├── useGameStore.ts # Zustand store │
+│ │ │ │ ├── useGameConnection.ts # PartySocket connection │
+│ │ │ │ └── useTimer.ts # Client-side timer tick │
+│ │ │ └── styles/ │
+│ │ └── server/ # PartyKit server │
+│ │ ├── src/ │
+│ │ │ ├── game.ts # Main PartyKit server class │
+│ │ │ ├── timerManager.ts # Timer tracking + alarm scheduling │
+│ │ │ └── dictionary.ts # Dictionary loading + Trie │
+│ │ └── data/ │
+│ │ └── enable.txt # ENABLE word list │
+│ │
+│ --- │
+│ Phased Implementation │
+│ │
+│ Phase 1: Foundation + Shared Core (sequential) │
+│ │
+│ Scaffold the project, define the shared contract, and implement all core game logic. This phase must complete first because both client and │
+│ server depend on it. │
+│ │
+│ Scaffolding: │
+│ - Initialize pnpm workspace with shared, client, server packages │
+│ - Scaffold React app with Vite (client/) │
+│ - Scaffold PartyKit server (server/) │
+│ - tsconfig.base.json with shared TypeScript config │
+│ │
+│ Shared types (shared/src/types.ts): │
+│ - All TypeScript types: Tile, PlacedTile, GameState, PlayerState │
+│ - ClientMessage / ServerMessage discriminated unions (the network contract) │
+│ - GameConfig (timer mode, duration, dictionary choice) │
+│ │
+│ Shared constants (shared/src/constants.ts): │
+│ - Tile distribution (100 tiles, letters/counts/values) │
+│ - 15x15 bonus square map (DL/TL/DW/TW) │
+│ - Game config defaults │
+│ │
+│ Shared game logic (pure functions, fully tested): │
+│ - shared/src/tileBag.ts — createTileBag(), drawTiles(), exchangeTiles() │
+│ - shared/src/words.ts — Trie class with insert() and has(), loadDictionary() parser │
+│ - shared/src/board.ts — isValidPlacement(), getFormedWords() │
+│ - shared/src/scoring.ts — scoreTurn() with DL/TL/DW/TW bonuses, 50-point all-tiles bonus │
+│ - shared/src/gameEngine.ts — pure state machine: createGame(), submitMove(), passTurn(), exchangeTiles(), checkEndConditions() │
+│ - Unit tests for all of the above │
+│ │
+│ --- │
+│ Phase 2: Client + Server in Parallel (via subagents) │
+│ │
+│ Once Phase 1 is complete, client and server can be built simultaneously since they both depend only on the shared package. │
+│ │
+│ Phase 2A: Client (subagent A) │
+│ │
+│ Build the full client UI with local hot-seat play, then wire up networking. │
+│ │
+│ Board + Tiles (static rendering): │
+│ - GameBoard.tsx + BoardCell.tsx — 15x15 CSS Grid with bonus square colors │
+│ - DraggableTile.tsx + TileRack.tsx — tile visuals (letter + point value), 7-tile rack │
+│ - Responsive layout: board fills width on mobile, side-by-side on desktop │
+│ │
+│ Drag-and-drop + mobile input: │
+│ - @dnd-kit integration: DndContext in board, useDraggable on tiles, useDroppable on cells │
+│ - Drag overlay follows pointer/finger (CSS transforms, GPU-accelerated) │
+│ - Tap-to-place as primary mobile input: tap tile (highlights) → tap cell (places) │
+│ - Pinch-to-zoom wrapper on the board │
+│ - Visual feedback: cell highlight on drag-over, snap animation, tile lift effect │
+│ │
+│ Local hot-seat play: │
+│ - useGameStore.ts — Zustand store driving local play via shared gameEngine │
+│ - GamePage.tsx — hot-seat mode: hands swap on turn change │
+│ - GameControls.tsx — Submit, Pass, Exchange, Shuffle buttons │
+│ - GameHeader.tsx + ScoreDisplay.tsx — player names and scores │
+│ │
+│ Timer display: │
+│ - TimerDisplay.tsx — both clocks, active clock pulses, color shifts white→yellow→red │
+│ - useTimer.ts — requestAnimationFrame countdown, MM:SS format (SS.T under 10s) │
+│ │
+│ Networking hookup (after server is ready): │
+│ - useGameConnection.ts — PartySocket hook: connect to room, translate server messages to Zustand updates │
+│ - HomePage.tsx — create game (pick timer mode + duration), join game (enter code or paste link) │
+│ │
+│ Modals + polish: │
+│ - GameOverModal.tsx — final scores, rematch button │
+│ - BlankTileModal.tsx — letter picker for blank tiles │
+│ - Exchange tiles modal │
+│ │
+│ Phase 2B: Server (subagent B) │
+│ │
+│ Build the PartyKit server that wraps shared game logic with networking, auth, and timers. │
+│ │
+│ Core server: │
+│ - server/src/game.ts — PartyKit server class: │
+│ - onConnect: assign player index (0 or 1), send waiting state or start game when 2 connected │
+│ - onMessage: parse ClientMessage, validate via shared gameEngine, broadcast ServerMessage │
+│ - onClose: mark disconnected (timer keeps running) │
+│ - alarm(): handle timer expiry │
+│ - Security: filter GameState before sending — each player only gets their own hand tiles, opponent hand sent as count only │
+│ │
+│ Dictionary: │
+│ - server/src/dictionary.ts — load ENABLE word list into Trie on Durable Object startup, cache in memory │
+│ │
+│ Timer manager: │
+│ - server/src/timerManager.ts — record turn start, compute elapsed on move, schedule DO alarms │
+│ - Sudden Death: alarm fires → game over, timed-out player loses │
+│ - Time Penalty: track cumulative time, compute point deductions at game end │
+│ - Periodic TIMER_SYNC messages every 5s during active play │
+│ │
+│ Room management: │
+│ - Generate 4-char room codes │
+│ - Handle reconnection (match player by ID in WebSocket URL query param) │
+│ - Rematch flow: same room, swap turn order │
+│ │
+│ --- │
+│ Phase 3: Integration + Polish (sequential) │
+│ │
+│ Converge the two workstreams and add final polish. │
+│ │
+│ - Wire useGameConnection.ts to server (swap local engine for network messages) │
+│ - End-to-end testing: two browser tabs, create game → join → play → game over → rematch │
+│ - Animations: tile snap (scale bounce), score popup (floating "+42"), word highlight │
+│ - Sound effects via Web Audio API (tile place, word accepted/rejected, timer warnings) │
+│ - Move history panel (collapsible) │
+│ - Connection status indicator │
+│ - Dark mode default, clean modern aesthetic │
+│ │
+│ Phase 4: Testing + Deployment │
+│ │
+│ - Comprehensive unit tests for shared/ (board edge cases, scoring combos, full game simulations) │
+│ - Component tests with React Testing Library │
+│ - Server integration tests (simulated 2-client game flows) │
+│ - Deploy client to Cloudflare Pages │
+│ - Deploy server via PartyKit CLI / wrangler │
+│ - GitHub Actions CI: lint, typecheck, test, build, deploy │
+│ │
+│ --- │
+│ Key Game Rules Reference │
+│ │
+│ - Board: 15x15 grid with standard bonus square layout (symmetric) │
+│ - Tiles: 100 total (balanced letter distribution), 2 blanks (0 points, represent any letter) │
+│ - Hand size: 7 tiles │
+│ - First move: must cover the center square │
+│ - Placement rules: tiles must form a single row or column, be contiguous (gaps filled by existing tiles), connect to at least one existing │
+│ tile │
+│ - Scoring: letter values × letter bonuses + word bonuses. Bonuses apply only on the turn placed. 50-point bonus for using all 7 tiles. │
+│ - End conditions: (a) player uses last tile + bag empty (bonus = sum of opponent's hand), (b) both players pass consecutively, (c) timer │
+│ expires (mode-dependent), (d) resignation │
+│ │
+│ Verification │
+│ │
+│ After each phase, verify by: │
+│ 1. Phase 1: Run pnpm test — all shared game logic unit tests pass. Game engine can simulate a full game programmatically. │
+│ 2. Phase 2A: Board renders 225 cells with correct bonus colors on mobile and desktop. Tiles can be placed via drag-and-drop (desktop) and │
+│ tap-to-place (mobile). Local hot-seat game plays to completion with correct scoring. │
+│ 3. Phase 2B: Server starts, accepts two WebSocket connections, validates moves, broadcasts state. Timer alarms fire correctly. Can be tested │
+│ with a simple WebSocket client script. │
+│ 4. Phase 3: Open two browser tabs, create a game in one, join via code in the other, play a full networked game to completion. Timers work. │
+│ Rematch works. Animations and sounds play. │
 │ 5. Phase 4: CI passes, deployed and playable at a public URL.


### PR DESCRIPTION
## Summary
- Remove all Scrabble trademark references across 8 files (docs, comments, tests), replacing with generic wording ("crossword-style", "word game", etc.)
- Replace the standard bonus square layout with an original "Blitz" layout — same bonus types/counts (8 TW, 17 DW, 12 TL, 24 DL) and 4-fold rotational symmetry, but completely different positions (TW off corners onto edge positions, DW in cross+diamond pattern, TL at edge midpoints + mid-board ring)
- Update all scoring and board tests to use the new bonus square coordinates

## Test plan
- [x] `pnpm --filter shared test` — all 142 tests pass with new positions
- [x] `pnpm test` — full suite (164 tests) green
- [x] `pnpm typecheck` — no type errors
- [x] `grep -ri scrabble` — zero results across entire codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)