### PR TITLE
Player-colored timer, desktop wheel zoom, disable desktop auto-zoom

### DIFF
--- a/packages/client/src/components/board/BoardCell.css
+++ b/packages/client/src/components/board/BoardCell.css
@@ -18,32 +18,32 @@
 }
 
 .board-cell:hover:not(.has-tile):not(.drag-over) {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--hover);
 }
 
 .board-cell.selected {
-  background: rgba(187, 134, 252, 0.2);
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
   box-shadow: inset 0 0 0 2px var(--tile-selected);
 }
 
 .board-cell.drag-over:not(.has-tile) {
-  background: rgba(187, 134, 252, 0.3);
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
   box-shadow: inset 0 0 0 2px var(--tile-selected);
 }
 
 .board-cell.cursor {
-  background: rgba(52, 211, 153, 0.2);
-  box-shadow: inset 0 0 0 2px rgba(52, 211, 153, 0.8);
+  background: color-mix(in srgb, var(--success) 20%, transparent);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--success) 80%, transparent);
   animation: cursor-pulse 1.5s ease-in-out infinite;
 }
 
 @keyframes cursor-pulse {
   0%,
   100% {
-    box-shadow: inset 0 0 0 2px rgba(52, 211, 153, 0.8);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--success) 80%, transparent);
   }
   50% {
-    box-shadow: inset 0 0 0 2px rgba(52, 211, 153, 1);
+    box-shadow: inset 0 0 0 2px var(--success);
   }
 }
 
@@ -67,14 +67,14 @@
 .bonus-label {
   font-size: 0.5rem;
   font-weight: 700;
-  color: rgba(255, 255, 255, 0.7);
+  color: #fff;
   text-transform: uppercase;
   line-height: 1;
 }
 
 .center-star {
   font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: #fff;
 }
 
 /* Tile in cell */
@@ -181,16 +181,16 @@
 
 /* Conflict indicator: both players placed on same spot */
 .board-cell.conflict {
-  box-shadow: inset 0 0 0 2px rgba(255, 87, 87, 0.8);
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--danger) 80%, transparent);
   animation: conflict-pulse 1s ease-in-out infinite;
 }
 
 @keyframes conflict-pulse {
   0%,
   100% {
-    box-shadow: inset 0 0 0 2px rgba(255, 87, 87, 0.6);
+    box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--danger) 60%, transparent);
   }
   50% {
-    box-shadow: inset 0 0 0 2px rgba(255, 87, 87, 1);
+    box-shadow: inset 0 0 0 2px var(--danger);
   }
 }

--- a/packages/client/src/components/board/BoardCell.tsx
+++ b/packages/client/src/components/board/BoardCell.tsx
@@ -93,10 +93,10 @@ export function BoardCell({
   const lastMoveStyle: React.CSSProperties | undefined = lastMoveEdges
     ? {
         ['--lm-shadow' as string]: [
-          lastMoveEdges.top && 'inset 0 2px 0 0 rgba(255, 171, 0, 0.45)',
-          lastMoveEdges.bottom && 'inset 0 -2px 0 0 rgba(255, 171, 0, 0.45)',
-          lastMoveEdges.left && 'inset 2px 0 0 0 rgba(255, 171, 0, 0.45)',
-          lastMoveEdges.right && 'inset -2px 0 0 0 rgba(255, 171, 0, 0.45)',
+          lastMoveEdges.top && 'inset 0 2px 0 0 var(--last-move)',
+          lastMoveEdges.bottom && 'inset 0 -2px 0 0 var(--last-move)',
+          lastMoveEdges.left && 'inset 2px 0 0 0 var(--last-move)',
+          lastMoveEdges.right && 'inset -2px 0 0 0 var(--last-move)',
         ]
           .filter(Boolean)
           .join(', '),

--- a/packages/client/src/components/board/GameBoard.css
+++ b/packages/client/src/components/board/GameBoard.css
@@ -36,7 +36,7 @@
   font-size: 0.75rem;
   background: var(--bg-card);
   color: var(--text);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--border-strong);
   border-radius: 4px;
   z-index: 5;
   cursor: pointer;

--- a/packages/client/src/components/board/GameBoard.tsx
+++ b/packages/client/src/components/board/GameBoard.tsx
@@ -50,8 +50,10 @@ export function GameBoard({ isDragging = false }: { isDragging?: boolean }) {
     const wasEmpty = prevPlacedCount.current === 0;
     prevPlacedCount.current = placedTiles.length;
 
+    const isTouchDevice = 'ontouchstart' in window;
     if (
       autoZoomEnabled &&
+      isTouchDevice &&
       wasEmpty &&
       placedTiles.length === 1 &&
       scaleRef.current <= 1.05 &&

--- a/packages/client/src/components/game/GameControls.css
+++ b/packages/client/src/components/game/GameControls.css
@@ -22,7 +22,7 @@
 }
 
 .move-error {
-  background: rgba(231, 76, 60, 0.2);
+  background: color-mix(in srgb, var(--danger) 20%, transparent);
   border: 1px solid var(--danger);
   color: var(--danger);
   padding: 6px 12px;

--- a/packages/client/src/components/game/GameHeader.css
+++ b/packages/client/src/components/game/GameHeader.css
@@ -26,6 +26,16 @@
   transition: all 0.2s ease;
 }
 
+.player-info.active.player-0 {
+  background: color-mix(in srgb, var(--player0) 15%, transparent);
+  box-shadow: 0 0 0 1px var(--player0);
+}
+
+.player-info.active.player-1 {
+  background: color-mix(in srgb, var(--player1) 15%, transparent);
+  box-shadow: 0 0 0 1px var(--player1);
+}
+
 .player-info.active {
   background: rgba(233, 69, 96, 0.2);
   box-shadow: 0 0 0 1px var(--accent);
@@ -123,6 +133,15 @@
   transition: stroke 0.3s ease;
 }
 
+/* Player-colored timer ring (normal urgency) */
+.turn-timer.normal.player-0 .timer-ring-progress {
+  stroke: var(--player0);
+}
+
+.turn-timer.normal.player-1 .timer-ring-progress {
+  stroke: var(--player1);
+}
+
 .turn-timer.warning .timer-ring-progress {
   stroke: var(--warning);
 }
@@ -137,6 +156,15 @@
   font-variant-numeric: tabular-nums;
   color: var(--text);
   min-width: 3ch;
+}
+
+/* Player-colored timer digits (normal urgency) */
+.turn-timer.normal.player-0 .timer-digits {
+  color: var(--player0);
+}
+
+.turn-timer.normal.player-1 .timer-digits {
+  color: var(--player1);
 }
 
 .turn-timer.warning .timer-digits {

--- a/packages/client/src/components/game/GameHeader.css
+++ b/packages/client/src/components/game/GameHeader.css
@@ -4,7 +4,7 @@
   justify-content: space-between;
   padding: 8px 36px 8px 36px;
   background: var(--bg-secondary);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid var(--border);
   position: relative;
 }
 
@@ -37,7 +37,7 @@
 }
 
 .player-info.active {
-  background: rgba(233, 69, 96, 0.2);
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
   box-shadow: 0 0 0 1px var(--accent);
 }
 
@@ -121,7 +121,7 @@
 
 .timer-ring-bg {
   fill: none;
-  stroke: rgba(255, 255, 255, 0.1);
+  stroke: var(--border);
   stroke-width: 3;
 }
 
@@ -212,7 +212,7 @@
   0%,
   100% {
     border-color: var(--danger);
-    box-shadow: inset 0 0 20px rgba(207, 102, 121, 0.15);
+    box-shadow: inset 0 0 20px color-mix(in srgb, var(--danger) 15%, transparent);
   }
   50% {
     border-color: transparent;
@@ -250,13 +250,13 @@
 
 .settings-btn:hover {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border);
 }
 
 .settings-modal-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--overlay);
   backdrop-filter: blur(4px);
   z-index: 100;
   display: flex;
@@ -273,7 +273,7 @@
   max-width: 400px;
   max-height: 80vh;
   overflow-y: auto;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border);
 }
 
 .settings-modal-header {
@@ -301,7 +301,7 @@
 
 .settings-modal-close:hover {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border);
 }
 
 /* In-game spectator settings */

--- a/packages/client/src/components/game/GameHeader.tsx
+++ b/packages/client/src/components/game/GameHeader.tsx
@@ -8,8 +8,10 @@ import './GameHeader.css';
 
 const TimerDisplay = React.memo(function TimerDisplay({
   isSpectator = false,
+  currentPlayerIndex = 0,
 }: {
   isSpectator?: boolean;
+  currentPlayerIndex?: number;
 }) {
   const timerUrgency = useSettingsStore((s) => s.timerUrgency);
   const { display, urgency, progress, isRunning } = useTimer();
@@ -18,11 +20,12 @@ const TimerDisplay = React.memo(function TimerDisplay({
 
   // Spectators see the timer but without urgency effects
   const showUrgency = timerUrgency && !isSpectator;
+  const playerClass = `player-${currentPlayerIndex}`;
 
   return (
     <>
       {showUrgency && urgency === 'critical' && <div className="critical-screen-flash" />}
-      <div className={`turn-timer ${showUrgency ? urgency : 'normal'}`}>
+      <div className={`turn-timer ${showUrgency ? urgency : 'normal'} ${playerClass}`}>
         <svg className="timer-ring" viewBox="0 0 40 40">
           <circle className="timer-ring-bg" cx="20" cy="20" r="17" />
           <circle
@@ -111,7 +114,7 @@ export function GameHeader({ isSpectator = false }: { isSpectator?: boolean }) {
         &#x2190;
       </button>
       <div
-        className={`player-info ${isRacing || currentPlayerIndex === 0 ? 'active' : ''} ${!isSpectator && isOnline && playerIndex === 0 ? 'you' : ''}`}
+        className={`player-info player-0 ${isRacing || currentPlayerIndex === 0 ? 'active' : ''} ${!isSpectator && isOnline && playerIndex === 0 ? 'you' : ''}`}
       >
         <div className="player-name">
           {getLabel(0)}
@@ -124,7 +127,7 @@ export function GameHeader({ isSpectator = false }: { isSpectator?: boolean }) {
       </div>
 
       <div className="game-info-center">
-        <TimerDisplay isSpectator={isSpectator} />
+        <TimerDisplay isSpectator={isSpectator} currentPlayerIndex={currentPlayerIndex} />
         <div className="bag-count">{tileBagCount} tiles left</div>
         {phase === 'playing' && (
           <div className={`turn-indicator ${!isSpectator && isMyTurn ? 'your-turn' : ''}`}>
@@ -142,7 +145,7 @@ export function GameHeader({ isSpectator = false }: { isSpectator?: boolean }) {
       </div>
 
       <div
-        className={`player-info ${isRacing || currentPlayerIndex === 1 ? 'active' : ''} ${!isSpectator && isOnline && playerIndex === 1 ? 'you' : ''}`}
+        className={`player-info player-1 ${isRacing || currentPlayerIndex === 1 ? 'active' : ''} ${!isSpectator && isOnline && playerIndex === 1 ? 'you' : ''}`}
       >
         <div className="player-name">
           {getLabel(1)}

--- a/packages/client/src/components/game/GameOverModal.css
+++ b/packages/client/src/components/game/GameOverModal.css
@@ -1,7 +1,7 @@
 .game-over-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -11,13 +11,14 @@
 
 .game-over-modal {
   background: var(--bg-secondary);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 12px;
   padding: 32px;
   text-align: center;
   min-width: 280px;
   max-width: 360px;
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 16px 48px var(--shadow);
+  animation: modal-enter 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .game-over-title {
@@ -50,13 +51,14 @@
   display: flex;
   justify-content: space-between;
   padding: 8px 16px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--hover);
   border-radius: 6px;
+  transition: background 0.2s ease;
 }
 
 .final-score.winner {
-  background: rgba(233, 69, 96, 0.15);
-  border: 1px solid rgba(233, 69, 96, 0.3);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
 .final-name {

--- a/packages/client/src/components/game/TurnBanner.css
+++ b/packages/client/src/components/game/TurnBanner.css
@@ -13,13 +13,13 @@
 
 .turn-banner-text {
   background: var(--bg-secondary);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--border-strong);
   color: var(--text);
   font-size: 1.2rem;
   font-weight: 700;
   padding: 10px 32px;
   border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 8px 24px var(--shadow);
 }
 
 @keyframes banner-lifecycle {

--- a/packages/client/src/components/settings/SettingsPanel.css
+++ b/packages/client/src/components/settings/SettingsPanel.css
@@ -8,7 +8,7 @@
   align-items: center;
   justify-content: space-between;
   padding: 14px 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid var(--border);
   cursor: pointer;
   gap: 16px;
 }
@@ -41,7 +41,7 @@
   width: 44px;
   height: 26px;
   border-radius: 13px;
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--border-strong);
   position: relative;
   transition: background 0.2s ease;
 }
@@ -75,7 +75,7 @@
 .theme-option {
   padding: 0.4rem 0.8rem;
   font-size: 0.85rem;
-  border: 1px solid rgba(128, 128, 128, 0.2);
+  border: 1px solid var(--border);
   border-radius: 6px;
   background: transparent;
   color: var(--text-muted);
@@ -91,6 +91,6 @@
 }
 
 .theme-option:hover:not(.active) {
-  background: rgba(128, 128, 128, 0.1);
-  border-color: rgba(128, 128, 128, 0.3);
+  background: var(--hover);
+  border-color: var(--border-strong);
 }

--- a/packages/client/src/components/tiles/BlankTilePicker.css
+++ b/packages/client/src/components/tiles/BlankTilePicker.css
@@ -1,7 +1,7 @@
 .blank-picker-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -11,13 +11,14 @@
 
 .blank-picker-modal {
   background: var(--bg-secondary);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 12px;
   padding: 24px;
   text-align: center;
   max-width: 320px;
   width: 90%;
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 16px 48px var(--shadow);
+  animation: modal-enter 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 
 .blank-picker-title {
@@ -55,7 +56,7 @@
 
 .blank-picker-letter:hover {
   transform: scale(1.08);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 2px 8px var(--shadow);
 }
 
 .blank-picker-letter:active {
@@ -67,11 +68,11 @@
   font-size: 0.9rem;
   background: transparent;
   color: var(--text-muted);
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   border-radius: 6px;
   cursor: pointer;
 }
 
 .blank-picker-cancel:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--hover);
 }

--- a/packages/client/src/components/tiles/TileRack.css
+++ b/packages/client/src/components/tiles/TileRack.css
@@ -19,7 +19,7 @@
 
 .tile-rack.rack-drag-over {
   box-shadow: 0 0 0 2px var(--accent);
-  background: rgba(187, 134, 252, 0.1);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .rack-tile {
@@ -36,14 +36,22 @@
   position: relative;
   user-select: none;
   -webkit-user-select: none;
-  transition: box-shadow 0.2s ease;
+  transition:
+    box-shadow 0.2s ease,
+    transform 0.15s ease;
   font-weight: 700;
   touch-action: none;
   will-change: transform;
 }
 
-.rack-tile:active {
+.rack-tile:hover:not(.placed):not(.dragging) {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px var(--shadow);
+}
+
+.rack-tile:active:not(.placed):not(.dragging) {
   cursor: grabbing;
+  transform: scale(0.95);
 }
 
 .rack-tile.dragging {
@@ -96,7 +104,7 @@
   border-radius: 4px;
   position: relative;
   font-weight: 700;
-  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+  box-shadow: 0 12px 24px var(--shadow);
   transform: scale(1.2);
   pointer-events: none;
   will-change: transform;

--- a/packages/client/src/hooks/usePinchZoom.ts
+++ b/packages/client/src/hooks/usePinchZoom.ts
@@ -138,6 +138,35 @@ export function usePinchZoom(minScale = 1, maxScale = 2.5, enabled = true) {
     });
   }, []);
 
+  const handleWheel = useCallback(
+    (e: React.WheelEvent) => {
+      if (!enabledRef.current) return;
+      e.preventDefault();
+
+      setState((prev) => {
+        const zoomFactor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+        const newScale = Math.min(maxScale, Math.max(minScale, prev.scale * zoomFactor));
+
+        // Zoom toward cursor position relative to the container
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const cursorX = e.clientX - rect.left - rect.width / 2;
+        const cursorY = e.clientY - rect.top - rect.height / 2;
+
+        const scaleDiff = newScale / prev.scale;
+        const tx = cursorX - scaleDiff * (cursorX - prev.translateX);
+        const ty = cursorY - scaleDiff * (cursorY - prev.translateY);
+
+        // Snap back to 1x if close
+        if (newScale < 1.1) {
+          return { scale: 1, translateX: 0, translateY: 0 };
+        }
+
+        return { scale: newScale, translateX: tx, translateY: ty };
+      });
+    },
+    [minScale, maxScale],
+  );
+
   const resetZoom = useCallback(() => {
     setState({ scale: 1, translateX: 0, translateY: 0 });
   }, []);
@@ -169,6 +198,7 @@ export function usePinchZoom(minScale = 1, maxScale = 2.5, enabled = true) {
       onTouchStart: handleTouchStart,
       onTouchMove: handleTouchMove,
       onTouchEnd: handleTouchEnd,
+      onWheel: handleWheel,
     },
     resetZoom,
     zoomToCell,

--- a/packages/client/src/pages/GamePage.css
+++ b/packages/client/src/pages/GamePage.css
@@ -79,18 +79,18 @@
 }
 
 .mode-option:hover {
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--hover);
 }
 
 .mode-option.selected {
   border-color: var(--accent);
-  background: rgba(233, 69, 96, 0.15);
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
 }
 
 .mode-name {
   font-size: 1.1rem;
   font-weight: 700;
-  color: #fff;
+  color: var(--text);
   margin-bottom: 4px;
 }
 
@@ -110,7 +110,7 @@
   font-family: monospace;
   font-weight: 700;
   letter-spacing: 0.3em;
-  color: #fff;
+  color: var(--text);
   background: var(--bg-secondary);
   padding: 16px 24px;
   border-radius: 12px;
@@ -173,7 +173,7 @@
 .reconnect-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.7);
+  background: var(--overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -201,7 +201,7 @@
 .spectator-settings {
   margin: 16px 0;
   padding: 12px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--hover);
   border-radius: 8px;
 }
 

--- a/packages/client/src/pages/HomePage.css
+++ b/packages/client/src/pages/HomePage.css
@@ -110,7 +110,7 @@
   justify-content: center;
   gap: 10px;
   background: var(--bg-card);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border);
   color: var(--text);
   font-size: 1.1rem;
   font-weight: 600;
@@ -123,7 +123,7 @@
 }
 
 .settings-link:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border);
   border-color: var(--accent);
 }
 
@@ -156,7 +156,7 @@
   flex: 1;
   padding: 12px 16px;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-strong);
   background: var(--bg-secondary);
   color: var(--text);
   font-size: 1.1rem;
@@ -171,7 +171,7 @@
   flex-direction: column;
   gap: 4px;
   padding-bottom: 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid var(--border);
 }
 
 .resume-btn {

--- a/packages/client/src/pages/SettingsPage.css
+++ b/packages/client/src/pages/SettingsPage.css
@@ -12,7 +12,7 @@
   align-items: center;
   gap: 12px;
   padding: 16px 20px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid var(--border);
 }
 
 .settings-title {

--- a/packages/client/src/styles/global.css
+++ b/packages/client/src/styles/global.css
@@ -30,6 +30,14 @@
   --player0: #4fc3f7; /* Light blue */
   --player1: #ff8a65; /* Warm orange */
 
+  /* Semantic borders & surfaces */
+  --border: rgba(255, 255, 255, 0.1);
+  --border-strong: rgba(255, 255, 255, 0.15);
+  --hover: rgba(255, 255, 255, 0.05);
+  --overlay: rgba(0, 0, 0, 0.7);
+  --shadow: rgba(0, 0, 0, 0.5);
+  --last-move: rgba(255, 171, 0, 0.45);
+
   --success: #03dac6;
   --warning: #ffab00;
   --danger: #cf6679;
@@ -110,11 +118,11 @@ button:disabled {
 .btn-secondary {
   background: var(--bg-card);
   color: var(--text);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border);
 }
 
 .btn-secondary:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border);
 }
 
 /* Back button - consistent across all screens */
@@ -139,11 +147,11 @@ button:disabled {
 
 .back-btn:hover:not(:disabled) {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--border);
 }
 
 .back-btn:active:not(:disabled) {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--border-strong);
   transform: scale(0.95);
 }
 
@@ -162,7 +170,7 @@ button:disabled {
   --accent: #9966cc;
   --accent-hover: #7744aa;
 
-  /* Tiles (dark on light - classic Scrabble) */
+  /* Tiles (dark on light) */
   --tile-bg: #2c2c2c;
   --tile-text: #f5f5f5;
   --tile-border: #1a1a1a;
@@ -185,8 +193,28 @@ button:disabled {
   --player0: #2196f3; /* Blue */
   --player1: #e65100; /* Orange */
 
+  /* Semantic borders & surfaces */
+  --border: rgba(0, 0, 0, 0.1);
+  --border-strong: rgba(0, 0, 0, 0.15);
+  --hover: rgba(0, 0, 0, 0.04);
+  --overlay: rgba(0, 0, 0, 0.5);
+  --shadow: rgba(0, 0, 0, 0.25);
+  --last-move: rgba(255, 140, 0, 0.4);
+
   /* Status colors (darker for contrast) */
   --success: #00a86b;
   --warning: #ff8c00;
   --danger: #c41e3a;
+}
+
+/* Shared keyframes */
+@keyframes modal-enter {
+  0% {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
 }

--- a/packages/client/src/styles/global.css
+++ b/packages/client/src/styles/global.css
@@ -26,6 +26,10 @@
   --tw: #6a3a3a; /* Muted Red */
   --center: #4a4a4a;
 
+  /* Player colors */
+  --player0: #4fc3f7; /* Light blue */
+  --player1: #ff8a65; /* Warm orange */
+
   --success: #03dac6;
   --warning: #ffab00;
   --danger: #cf6679;
@@ -176,6 +180,10 @@ button:disabled {
   --dw: #f0e68c; /* Khaki yellow */
   --tw: #dc143c; /* Crimson red */
   --center: #ffa500; /* Orange */
+
+  /* Player colors */
+  --player0: #2196f3; /* Blue */
+  --player1: #e65100; /* Orange */
 
   /* Status colors (darker for contrast) */
   --success: #00a86b;


### PR DESCRIPTION
## Summary
- **Timer matches active player color**: Timer ring and digits use player-specific colors (blue for Player 1, orange for Player 2) during normal urgency, still switching to warning/danger colors as time runs low. Player info panels also highlight with matching colors.
- **Desktop wheel zoom**: Added mouse wheel zoom support to `usePinchZoom` — scrolling zooms toward the cursor position, with snap-back to 1x when close. Desktop users can now freely control board zoom.
- **Disable auto-zoom on desktop**: Auto-zoom (triggered on first tile placement) now only fires on touch devices, since desktop users have manual zoom control via scroll wheel.
- **Semantic CSS variables for theming**: Added `--border`, `--border-strong`, `--hover`, `--overlay`, `--shadow`, and `--last-move` variables to both dark and light themes. Replaced all hardcoded `rgba()` values across 14 CSS files with `var()` references and `color-mix()` for theme-aware transparency. Light theme now works correctly across all components.
- **Shared modal animation**: Moved `modal-enter` keyframe to `global.css` so both game-over modal and blank tile picker use it reliably.

Note: The duplicate timer issue was already resolved in #30.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — all 164 tests pass
- [ ] Visual check: timer color matches active player (blue/orange), switches to yellow/red on urgency
- [ ] Desktop: scroll wheel zooms board in/out, auto-zoom does not trigger on tile placement
- [ ] Mobile: touch pinch-zoom and auto-zoom still work as before
- [ ] Light theme: verify all components use correct colors (no hardcoded dark-theme rgba leaking through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)